### PR TITLE
Self-host fonts and update Content Security Policy to enhance performance and security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 dist/
-public/fonts/
+src/assets/fonts/
 .env
 .env.local
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+public/fonts/
 .env
 .env.local
 *.log

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="POURcast — Your Curb Cut to Certification. Study for CPACC and other accessibility certifications." />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'" />
     <title>POURcast — Your Curb Cut to Certification</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/pourcast/fonts/atkinson-hyperlegible-400-normal.woff2') format('woff2');
+  src: url('./assets/fonts/atkinson-hyperlegible-400-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -18,7 +18,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/pourcast/fonts/atkinson-hyperlegible-700-normal.woff2') format('woff2');
+  src: url('./assets/fonts/atkinson-hyperlegible-700-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -26,7 +26,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/pourcast/fonts/atkinson-hyperlegible-400-italic.woff2') format('woff2');
+  src: url('./assets/fonts/atkinson-hyperlegible-400-italic.woff2') format('woff2');
 }
 
 @font-face {
@@ -34,7 +34,7 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url('/pourcast/fonts/atkinson-hyperlegible-700-italic.woff2') format('woff2');
+  src: url('./assets/fonts/atkinson-hyperlegible-700-italic.woff2') format('woff2');
 }
 
 /* Inter — self-hosted (variable font) */
@@ -43,7 +43,7 @@
   font-style: normal;
   font-weight: 400 700;
   font-display: swap;
-  src: url('/pourcast/fonts/inter-400-700-normal.woff2') format('woff2');
+  src: url('./assets/fonts/inter-400-700-normal.woff2') format('woff2');
 }
 
 /* Lora — self-hosted (variable font) */
@@ -52,7 +52,7 @@
   font-style: normal;
   font-weight: 400 700;
   font-display: swap;
-  src: url('/pourcast/fonts/lora-400-700-normal.woff2') format('woff2');
+  src: url('./assets/fonts/lora-400-700-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -60,7 +60,7 @@
   font-style: italic;
   font-weight: 400 700;
   font-display: swap;
-  src: url('/pourcast/fonts/lora-400-700-italic.woff2') format('woff2');
+  src: url('./assets/fonts/lora-400-700-italic.woff2') format('woff2');
 }
 
 /* Comic Neue — self-hosted */
@@ -69,7 +69,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/pourcast/fonts/comic-neue-400-normal.woff2') format('woff2');
+  src: url('./assets/fonts/comic-neue-400-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -77,7 +77,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/pourcast/fonts/comic-neue-700-normal.woff2') format('woff2');
+  src: url('./assets/fonts/comic-neue-700-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -85,7 +85,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/pourcast/fonts/comic-neue-400-italic.woff2') format('woff2');
+  src: url('./assets/fonts/comic-neue-400-italic.woff2') format('woff2');
 }
 
 @font-face {
@@ -93,7 +93,7 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url('/pourcast/fonts/comic-neue-700-italic.woff2') format('woff2');
+  src: url('./assets/fonts/comic-neue-700-italic.woff2') format('woff2');
 }
 
 /* Default: Atkinson Hyperlegible */

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,13 @@
    FONT FAMILIES — driven by data-font-family on <html>
    =================================================== */
 
-/* Atkinson Hyperlegible from Google Fonts */
+/* Atkinson Hyperlegible — self-hosted */
 @font-face {
   font-family: 'Atkinson Hyperlegible';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt23C1KxNDXMspQ1lPyU89-1h6ONRlW45G04pIo.woff2') format('woff2');
+  src: url('/pourcast/fonts/atkinson-hyperlegible-400-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -18,7 +18,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt73C1KxNDXMspQ1lPyU89-1h6ONRlW45G8WbcNki-h.woff2') format('woff2');
+  src: url('/pourcast/fonts/atkinson-hyperlegible-700-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -26,7 +26,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt43C1KxNDXMspQ1lPyU89-1h6ONRlW45G056qk.woff2') format('woff2');
+  src: url('/pourcast/fonts/atkinson-hyperlegible-400-italic.woff2') format('woff2');
 }
 
 @font-face {
@@ -34,25 +34,25 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt93C1KxNDXMspQ1lPyU89-1h6ONRlW45G8e6Ki_-Bh.woff2') format('woff2');
+  src: url('/pourcast/fonts/atkinson-hyperlegible-700-italic.woff2') format('woff2');
 }
 
-/* Inter from Google Fonts (variable font) */
+/* Inter — self-hosted (variable font) */
 @font-face {
   font-family: 'Inter';
   font-style: normal;
   font-weight: 400 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2') format('woff2');
+  src: url('/pourcast/fonts/inter-400-700-normal.woff2') format('woff2');
 }
 
-/* Lora from Google Fonts (variable font) */
+/* Lora — self-hosted (variable font) */
 @font-face {
   font-family: 'Lora';
   font-style: normal;
   font-weight: 400 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/lora/v37/0QIvMX1D_JOuMwr7Iw.woff2') format('woff2');
+  src: url('/pourcast/fonts/lora-400-700-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -60,16 +60,16 @@
   font-style: italic;
   font-weight: 400 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/lora/v37/0QIhMX1D_JOuMw_LIftL.woff2') format('woff2');
+  src: url('/pourcast/fonts/lora-400-700-italic.woff2') format('woff2');
 }
 
-/* Comic Neue from Google Fonts */
+/* Comic Neue — self-hosted */
 @font-face {
   font-family: 'Comic Neue';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/comicneue/v9/4UaHrEJDsxBrF37olUeD96rp5w.woff2') format('woff2');
+  src: url('/pourcast/fonts/comic-neue-400-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -77,7 +77,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/comicneue/v9/4UaErEJDsxBrF37olUeD_xHM8pxULg.woff2') format('woff2');
+  src: url('/pourcast/fonts/comic-neue-700-normal.woff2') format('woff2');
 }
 
 @font-face {
@@ -85,7 +85,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/comicneue/v9/4UaFrEJDsxBrF37olUeD96_Z5btx.woff2') format('woff2');
+  src: url('/pourcast/fonts/comic-neue-400-italic.woff2') format('woff2');
 }
 
 @font-face {
@@ -93,7 +93,7 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url('https://fonts.gstatic.com/s/comicneue/v9/4UaarEJDsxBrF37olUeD96_RXp5kLCND.woff2') format('woff2');
+  src: url('/pourcast/fonts/comic-neue-700-italic.woff2') format('woff2');
 }
 
 /* Default: Atkinson Hyperlegible */


### PR DESCRIPTION
This pull request updates the way fonts are loaded in the application by switching from Google Fonts CDN to self-hosted font files. It also tightens the Content Security Policy to disallow external font sources. These changes improve privacy, performance, and security by ensuring all fonts are served locally.

**Font loading and hosting:**

* All `@font-face` declarations in `src/index.css` now reference self-hosted `.woff2` font files instead of loading fonts from Google Fonts (`fonts.gstatic.com`). This applies to Atkinson Hyperlegible, Inter, Lora, and Comic Neue font families.

**Security policy updates:**

* The Content Security Policy in `index.html` is updated to remove `https://fonts.gstatic.com` from the `font-src` directive, ensuring that only self-hosted fonts can be loaded.