### PR TITLE
Feature/#16 more

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { domain2 } from './data/questions/cpacc-domain2';
 import { domain3 } from './data/questions/cpacc-domain3';
 import { wasDomain1 } from './data/questions/was-domain1';
 import { wasDomain2 } from './data/questions/was-domain2';
+import { wasDomain3 } from './data/questions/was-domain3';
 import { getQuestionsByIds } from './utils/getQuestionsByIds';
 import { getLocalDateString, getYesterdayDateString } from './utils/localDate';
 
@@ -24,7 +25,7 @@ const FlaggedQuestionsPage = lazy(() => import('./components/flagged/FlaggedQues
 const ActivityPage = lazy(() => import('./components/activity/ActivityPage'));
 
 const CPACC_DOMAINS = [domain1, domain2, domain3];
-const WAS_DOMAINS = [wasDomain1, wasDomain2];
+const WAS_DOMAINS = [wasDomain1, wasDomain2, wasDomain3];
 const ALL_DOMAINS = [...CPACC_DOMAINS, ...WAS_DOMAINS];
 
 const DOMAINS_BY_COURSE = {

--- a/src/components/dashboard/DomainCard.jsx
+++ b/src/components/dashboard/DomainCard.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ChevronRight, BookOpen, Brain, Scale, ShieldCheck, User, Globe, Code } from 'lucide-react';
+import { ChevronRight, BookOpen, Brain, Scale, ShieldCheck, User, Globe, Code, Wrench } from 'lucide-react';
 
 const ICON_MAP = {
   user: User,
@@ -8,6 +8,7 @@ const ICON_MAP = {
   shield: ShieldCheck,
   globe: Globe,
   code: Code,
+  wrench: Wrench,
   default: BookOpen,
 };
 

--- a/src/data/knowledgeBase/index.js
+++ b/src/data/knowledgeBase/index.js
@@ -2204,7 +2204,7 @@ export const topics = [
     slug: 'maturity-models',
     title: 'Accessibility Maturity Models',
     category: 'Organizational Strategy',
-    applicableTo: ['cpacc'],
+    applicableTo: ['cpacc', 'was'],
     summary: 'Frameworks for assessing and improving an organization\'s accessibility practices across dimensions like culture, process, technology, and training.',
     content: [
       {
@@ -2260,7 +2260,7 @@ export const topics = [
     slug: 'vpat',
     title: 'VPAT & Accessibility Conformance Reports',
     category: 'Organizational Strategy',
-    applicableTo: ['cpacc'],
+    applicableTo: ['cpacc', 'was'],
     summary: 'The Voluntary Product Accessibility Template (VPAT) is used to document how ICT products conform to accessibility standards, producing an Accessibility Conformance Report (ACR).',
     content: [
       {
@@ -2312,7 +2312,7 @@ export const topics = [
     slug: 'procurement-accessibility',
     title: 'Accessibility in Procurement',
     category: 'Organizational Strategy',
-    applicableTo: ['cpacc'],
+    applicableTo: ['cpacc', 'was'],
     summary: 'Including accessibility requirements in purchasing decisions to ensure that acquired products and services are accessible to people with disabilities.',
     content: [
       {
@@ -3418,6 +3418,881 @@ export const topics = [
       'SC 2.5.8 Target Size Minimum (AA, WCAG 2.2): 24x24 CSS pixels',
       'Never use user-scalable=no or maximum-scale=1 in viewport meta tag',
       'SC 1.3.4 Orientation (AA): do not lock to portrait or landscape unless essential'
+    ]
+  },
+
+  // ============================================================
+  // WAS-SPECIFIC: ARIA & ACCESSIBILITY TREE
+  // ============================================================
+  {
+    slug: 'accessibility-tree',
+    title: 'The Accessibility Tree',
+    category: 'ARIA & Semantics',
+    applicableTo: ['was'],
+    summary: 'The accessibility tree is a simplified representation of the DOM that browsers expose to assistive technologies via platform accessibility APIs, containing each element\'s name, role, value, and state.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'When a browser parses an HTML document, it builds the DOM (Document Object Model). From the DOM, the browser generates a parallel structure called the accessibility tree — a simplified representation optimized for assistive technologies. The accessibility tree strips out purely visual information and exposes the semantic meaning of elements: their role, name, value, state, and relationships.'
+      },
+      {
+        type: 'heading',
+        text: 'How the Accessibility Tree Is Built'
+      },
+      {
+        type: 'list',
+        items: [
+          'The browser processes the DOM and creates accessible objects for elements with semantic meaning',
+          'Native HTML elements provide implicit roles: <button> becomes role="button", <nav> becomes role="navigation"',
+          'ARIA attributes override or supplement native semantics: role, aria-label, aria-expanded, etc.',
+          'CSS can affect the tree: display:none and visibility:hidden remove elements from the tree; aria-hidden="true" hides elements from AT but keeps them visible',
+          'The accessibility tree is what the operating system\'s accessibility API exposes to assistive technologies'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Accessible Object Properties'
+      },
+      {
+        type: 'list',
+        items: [
+          'Name: the accessible label that identifies the element (from text content, aria-label, aria-labelledby, alt attribute, or title)',
+          'Role: what kind of element it is (button, link, heading, textbox, etc.)',
+          'Value: the current value (e.g., text in an input field, the current slider position)',
+          'State: dynamic properties like expanded/collapsed, checked/unchecked, disabled, selected',
+          'Description: supplementary information (from aria-describedby or title)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'The Accessibility API Chain'
+      },
+      {
+        type: 'paragraph',
+        text: 'The chain works as follows: HTML + ARIA → DOM → Accessibility Tree → Platform Accessibility API (e.g., UIA on Windows, AX API on macOS, ATK/AT-SPI on Linux) → Assistive Technology (e.g., JAWS, NVDA, VoiceOver). The HTML Accessibility API Mappings (HTML-AAM) specification defines how native HTML elements map to accessibility API roles and properties.'
+      },
+      {
+        type: 'heading',
+        text: 'Debugging the Accessibility Tree'
+      },
+      {
+        type: 'list',
+        items: [
+          'Chrome DevTools: Elements panel → Accessibility pane shows computed accessible name, role, and properties',
+          'Firefox DevTools: Accessibility Inspector provides a full tree view of accessible objects',
+          'Chrome DevTools also has a "Full Accessibility Tree" view that replaces the DOM tree with the a11y tree',
+          'These tools help identify missing names, incorrect roles, or hidden elements that should be exposed'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: The accessibility tree is NOT the DOM — it is a simplified version built from the DOM. Native HTML provides implicit roles; ARIA overrides or adds semantics. The tree exposes name, role, value, state, and description. CSS display:none removes from both visual display AND the accessibility tree. aria-hidden="true" removes from the accessibility tree only.'
+      }
+    ],
+    relatedTopics: ['aria-overview', 'aria-roles', 'semantic-html', 'screen-readers'],
+    examTips: [
+      'The accessibility tree is a simplified representation of the DOM for assistive technologies',
+      'Native HTML provides implicit ARIA roles — ARIA attributes override or supplement them',
+      'Five key properties: name, role, value, state, description',
+      'display:none hides from both display AND accessibility tree',
+      'aria-hidden="true" hides from accessibility tree only — never use on focusable elements',
+      'HTML-AAM specification defines native HTML to accessibility API mappings'
+    ]
+  },
+  {
+    slug: 'accessible-names-descriptions',
+    title: 'Accessible Names & Descriptions',
+    category: 'ARIA & Semantics',
+    applicableTo: ['was'],
+    summary: 'Every interactive element needs an accessible name so assistive technologies can identify it. The accessible name computation algorithm defines the priority order for determining an element\'s name.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'An accessible name is a short string that labels an element for assistive technology users. Every interactive element — links, buttons, form fields, widgets — must have an accessible name (WCAG SC 4.1.2 Name, Role, Value). An accessible description provides additional information beyond the name, announced by screen readers after the name, often after a brief pause.'
+      },
+      {
+        type: 'heading',
+        text: 'The Accessible Name Computation'
+      },
+      {
+        type: 'paragraph',
+        text: 'Browsers use a defined algorithm (the Accessible Name and Description Computation specification) to determine an element\'s name. When multiple naming sources exist, the source with the highest priority wins. The priority order from highest to lowest is:'
+      },
+      {
+        type: 'list',
+        items: [
+          '1. aria-labelledby — references one or more elements by ID; their text content becomes the name. Highest priority and can concatenate text from multiple elements',
+          '2. aria-label — a string directly on the element. Overrides all native naming methods but is itself overridden by aria-labelledby',
+          '3. Native labeling — varies by element type: <label> for form controls, alt for images, text content for links and buttons, <caption> for tables, <legend> for fieldsets',
+          '4. title attribute — used as a last resort if no other name source exists. Generally not recommended as the primary naming method because tooltip behavior is inconsistent'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Accessible Descriptions'
+      },
+      {
+        type: 'list',
+        items: [
+          'aria-describedby references element(s) whose text content forms the description',
+          'Descriptions supplement the name with additional context (e.g., format instructions for an input field)',
+          'Screen readers announce the description after the name, typically with a brief pause',
+          'The title attribute may serve as an accessible description if not already used as the name'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Common Naming Patterns'
+      },
+      {
+        type: 'list',
+        items: [
+          'Buttons: text content inside the <button> element ("Submit", "Close")',
+          'Links: text content between <a> tags; for icon-only links, use aria-label or visually hidden text',
+          'Images: alt attribute; decorative images use alt="" (empty string)',
+          'Form fields: associated <label> via for/id or wrapping; aria-label as fallback',
+          'Icon buttons: aria-label on the button element, with aria-hidden="true" on the icon SVG',
+          'Groups of radio buttons or checkboxes: <fieldset> with <legend> for the group name'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: The name computation priority is: aria-labelledby > aria-label > native label (text content, alt, <label>) > title. aria-labelledby overrides everything, even aria-label. aria-label overrides native text content. Know the difference between accessible name (identifies the element) and accessible description (supplementary info via aria-describedby). WCAG 2.5.3 Label in Name (Level A) requires that the visible text label is included in the accessible name.'
+      }
+    ],
+    relatedTopics: ['aria-overview', 'aria-states-properties', 'form-accessibility', 'accessibility-tree'],
+    examTips: [
+      'Priority: aria-labelledby > aria-label > native label > title',
+      'aria-labelledby can reference multiple IDs — text is concatenated in order',
+      'aria-label overrides native text content (link text, button text)',
+      'SC 4.1.2 Name, Role, Value: every interactive element needs an accessible name',
+      'SC 2.5.3 Label in Name: visible label text must be included in the accessible name',
+      'Accessible description (aria-describedby) supplements the name — announced after a pause'
+    ]
+  },
+
+  // ============================================================
+  // WAS-SPECIFIC: IMPLEMENTATION PATTERNS
+  // ============================================================
+  {
+    slug: 'standard-vs-custom-controls',
+    title: 'Standard Controls vs. Custom Controls',
+    category: 'ARIA & Semantics',
+    applicableTo: ['was'],
+    summary: 'Native HTML controls provide built-in keyboard support, roles, and states for free. Custom controls require ARIA roles, keyboard handlers, and focus management — use them only when native HTML cannot meet the requirement.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'The choice between standard HTML controls and custom ARIA widgets significantly impacts accessibility. Native HTML elements like <button>, <input>, <select>, and <a> provide built-in keyboard support, implicit ARIA roles, state management, and consistent behavior across assistive technologies — all without any additional code.'
+      },
+      {
+        type: 'heading',
+        text: 'What Native HTML Provides for Free'
+      },
+      {
+        type: 'list',
+        items: [
+          'Implicit ARIA roles: <button> is automatically role="button", <a href> is role="link"',
+          'Keyboard support: buttons respond to Enter and Space, links respond to Enter, form controls support Tab navigation',
+          'Focus management: native interactive elements are in the tab order by default',
+          'State communication: <input type="checkbox"> automatically exposes checked state to AT',
+          'Cross-browser and cross-AT compatibility: thoroughly tested by browser vendors'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'When Custom Controls Are Necessary'
+      },
+      {
+        type: 'list',
+        items: [
+          'Complex widgets not available in HTML: tab panels, tree views, comboboxes with autocomplete, date pickers',
+          'Specific design requirements that standard controls cannot accommodate',
+          'Highly interactive web applications requiring specialized interaction patterns',
+          'When branding or design systems require visual customization beyond CSS styling of native elements'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Requirements for Accessible Custom Controls'
+      },
+      {
+        type: 'list',
+        items: [
+          'Assign the correct ARIA role (e.g., role="tablist", role="tab", role="tabpanel")',
+          'Manage ARIA states (aria-selected, aria-expanded, aria-checked, etc.)',
+          'Implement full keyboard interaction per the ARIA Authoring Practices Guide (APG) patterns',
+          'Manage focus within composite widgets using roving tabindex or aria-activedescendant',
+          'Provide an accessible name for the widget and its interactive parts',
+          'Test with multiple screen reader and browser combinations'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'The 5 Rules of ARIA'
+      },
+      {
+        type: 'list',
+        items: [
+          'Rule 1: Use native HTML instead of ARIA if possible — it already has the semantics and behavior built in',
+          'Rule 2: Do not change native semantics unless you really have to (e.g., don\'t add role="button" to a heading)',
+          'Rule 3: All interactive ARIA controls must be usable with the keyboard',
+          'Rule 4: Do not use role="presentation" or aria-hidden="true" on a focusable element',
+          'Rule 5: All interactive elements must have an accessible name'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: Always prefer native HTML over custom ARIA widgets (Rule 1 of ARIA). A custom role completely overrides the native role — <li role="button"> is announced as a button, not a list item. ARIA does NOT add keyboard behavior — the author must implement it. The application role should be used very sparingly as it overrides screen reader navigation keystrokes.'
+      }
+    ],
+    relatedTopics: ['aria-overview', 'aria-widget-patterns', 'semantic-html', 'aria-roles'],
+    examTips: [
+      'Always prefer native HTML over custom ARIA — the first rule of ARIA',
+      'ARIA roles override native roles completely',
+      'ARIA adds semantics only — it does NOT change browser behavior or keyboard support',
+      'Custom widgets require: correct role + ARIA states + keyboard handlers + focus management + accessible name',
+      'The application role disables screen reader navigation keystrokes — use very sparingly',
+      'Test custom widgets across multiple screen reader + browser combinations'
+    ]
+  },
+  {
+    slug: 'spa-accessibility',
+    title: 'Single Page Application Accessibility',
+    category: 'ARIA & Semantics',
+    applicableTo: ['was'],
+    summary: 'SPAs load content dynamically without full page reloads, creating accessibility challenges: screen readers miss route changes, focus gets lost, and the page title may not update.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Single Page Applications (SPAs) use JavaScript frameworks (React, Vue, Angular) to dynamically update content without full page reloads. While this improves performance, it creates significant accessibility challenges. Screen readers rely on page load events to announce the page title and provide a structural summary — SPAs do not fire these events when navigating between views.'
+      },
+      {
+        type: 'heading',
+        text: 'Key Accessibility Challenges in SPAs'
+      },
+      {
+        type: 'list',
+        items: [
+          'Screen readers do not announce route changes because there is no traditional page load event',
+          'Focus remains on the element that triggered navigation (e.g., a link) instead of moving to the new content',
+          'The document title (document.title) may not update to reflect the new view',
+          'Content loaded via AJAX is not automatically announced to screen readers',
+          'Browser back/forward navigation behavior may be inconsistent'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Recommended SPA Accessibility Patterns'
+      },
+      {
+        type: 'list',
+        items: [
+          'Update document.title via JavaScript on every route change to reflect the current view',
+          'Move focus to the new content — typically the main heading (h1) or the <main> element',
+          'Use aria-live regions to announce the route change (e.g., "New page: About Us")',
+          'Ensure skip navigation links still work correctly in the SPA context',
+          'Manage focus when content is loaded asynchronously — send focus to new content when it is the result of a user action'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'AJAX Content Notifications'
+      },
+      {
+        type: 'list',
+        items: [
+          'If AJAX content is loaded as a direct result of a user action (e.g., clicking a button), notify the user — either by moving focus or using aria-live',
+          'If AJAX content is loaded passively (not triggered by the user), notification may not be needed unless the content is urgent',
+          'The aria-live container must exist in the DOM before injecting content — dynamically created live regions are unreliable',
+          'Use aria-live="polite" for non-urgent updates and aria-live="assertive" only for critical alerts'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: SPAs do NOT fire page load events, so screen readers miss route changes. Three remedies: (1) update document.title, (2) move focus to the new content, (3) use aria-live announcements. For AJAX content: if user-triggered, notify; if passive, notification depends on urgency. The aria-live container must already exist in the DOM before content is injected.'
+      }
+    ],
+    relatedTopics: ['aria-live-regions', 'javascript-accessibility', 'aria-overview', 'screen-readers'],
+    examTips: [
+      'SPAs do not fire page load events — screen readers miss route changes',
+      'Three solutions: update document.title, move focus, and/or use aria-live',
+      'User-triggered AJAX content should notify the user; passive content may not need notification',
+      'aria-live container must exist in the DOM before content is injected',
+      'Focus should move to the main heading or main content region after navigation',
+      'Browser back/forward navigation must be supported — use the History API correctly'
+    ]
+  },
+  {
+    slug: 'javascript-accessibility',
+    title: 'JavaScript & Accessibility',
+    category: 'ARIA & Semantics',
+    applicableTo: ['was'],
+    summary: 'JavaScript can improve or damage accessibility. Accessible JavaScript requires progressive enhancement, device-independent event handlers, proper focus management, and correct ARIA state updates.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Modern assistive technologies fully support JavaScript — there are no inherent barriers. However, JavaScript must be coded with accessibility in mind. The progressive enhancement approach means essential content and functionality are available even when JavaScript is unavailable or fails to load. JavaScript enables accessible dynamic content when used correctly: toggling ARIA states, managing focus, and announcing updates via live regions.'
+      },
+      {
+        type: 'heading',
+        text: 'Device-Independent Event Handlers'
+      },
+      {
+        type: 'list',
+        items: [
+          'onClick on <button> and <a> automatically includes both mouse and keyboard activation — Enter for links, Enter/Space for buttons',
+          'onClick on a non-semantic <div> or <span> provides mouse support only — you must add a keydown/keyup handler for Enter/Space and add tabindex="0" for focusability',
+          'Avoid device-dependent event handlers like onMouseOver without a keyboard equivalent (onFocus)',
+          'Multi-event elements (e.g., hover to expand + click to follow link) are problematic for keyboard, touch, and screen reader users',
+          'Functionality must be available via keyboard, mouse, touch, and voice input'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Focus Management'
+      },
+      {
+        type: 'list',
+        items: [
+          'Focus movement must be predictable and follow user expectations',
+          'When a dialog opens, focus should move into the dialog; when it closes, focus returns to the trigger element',
+          'When content is added dynamically, add it after the user\'s current focus position — screen reader users move forward, not backward',
+          'Use element.focus() to programmatically move focus when needed',
+          'Trap focus inside modal dialogs — Tab should cycle within the dialog, not escape to the background page'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Managing State with ARIA'
+      },
+      {
+        type: 'list',
+        items: [
+          'Toggle ARIA state attributes with JavaScript: aria-expanded, aria-selected, aria-checked, aria-pressed, aria-hidden',
+          'Standard HTML controls manage state automatically; custom controls need explicit ARIA state management',
+          'Dynamic updates that do not receive focus must be announced via ARIA live regions (aria-live="polite" or role="alert")',
+          'The live region container must be present in the DOM at page load, then content is injected dynamically'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: onClick on a <button> includes keyboard support (Enter/Space) — but onClick on a <div> does NOT. Progressive enhancement = essential content works without JavaScript. Two focus management strategies for composite widgets: roving tabindex (move tabindex="0" between children) and aria-activedescendant (keep DOM focus on container, change the active descendant ID). ARIA live region containers must exist in the DOM before injecting content.'
+      }
+    ],
+    relatedTopics: ['spa-accessibility', 'aria-states-properties', 'aria-live-regions', 'standard-vs-custom-controls'],
+    examTips: [
+      'onClick on semantic elements (button, link) includes keyboard support; on non-semantic elements it does NOT',
+      'Progressive enhancement: essential content available without JavaScript',
+      'Focus management: dialog opens → focus in; dialog closes → focus returns to trigger',
+      'Add dynamic content AFTER the user\'s current focus position',
+      'Roving tabindex vs. aria-activedescendant: two strategies for focus within composite widgets',
+      'ARIA live region containers must exist in the DOM at page load'
+    ]
+  },
+
+  // ============================================================
+  // WAS-SPECIFIC: STANDARDS & GUIDELINES
+  // ============================================================
+  {
+    slug: 'atag-overview',
+    title: 'Authoring Tool Accessibility Guidelines (ATAG)',
+    category: 'Standards & Guidelines',
+    applicableTo: ['was'],
+    summary: 'ATAG 2.0 ensures authoring tools (CMS, WYSIWYG editors, social media platforms) are accessible themselves and help authors produce accessible content.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'The Authoring Tool Accessibility Guidelines (ATAG) 2.0 is a W3C standard that addresses the accessibility of software used to create web content. Authoring tools include CMS platforms (WordPress, Drupal), WYSIWYG editors, site builders, form generators, social media platforms, learning management systems, and any tool that produces web content.'
+      },
+      {
+        type: 'heading',
+        text: 'ATAG\'s Two Parts'
+      },
+      {
+        type: 'list',
+        items: [
+          'Part A: Make the authoring tool user interface accessible — the tool itself must be usable by people with disabilities, including those who use assistive technologies',
+          'Part B: Support the production of accessible content — the tool should guide, assist, and automate the creation of accessible output (e.g., prompting for alt text on image upload, producing well-structured markup)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'ATAG Structure'
+      },
+      {
+        type: 'list',
+        items: [
+          'Like WCAG, ATAG is organized into Principles, Guidelines, and Success Criteria at three conformance levels (A, AA, AAA)',
+          'Part A principles cover: perceivable editing views, operable editing views, understandable editing views, and robust editing views',
+          'Part B principles cover: automated accessible content production, assisting authors to produce accessible content, and promoting accessibility features',
+          'Implementing ATAG 2.0 is the non-normative supporting document (similar to Understanding WCAG)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Why ATAG Matters for WAS'
+      },
+      {
+        type: 'list',
+        items: [
+          'Content created by authoring tools often inherits accessibility issues from the tool itself',
+          'Understanding ATAG helps evaluate CMS platforms and other content creation tools during procurement',
+          'Knowing whether a tool supports accessible output informs remediation strategies — some issues are best fixed at the tool level',
+          'While ATAG currently references WCAG 2.0, the new WCAG 2.1/2.2 success criteria can be incorporated into ATAG analysis'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: ATAG has two parts: Part A = the authoring tool UI is accessible; Part B = the tool supports producing accessible content. ATAG is a W3C Recommendation, like WCAG. Know the three WAI guidelines: WCAG (content), ATAG (authoring tools), UAAG (user agents/browsers). ATAG currently references WCAG 2.0 but can be applied with WCAG 2.1/2.2 criteria.'
+      }
+    ],
+    relatedTopics: ['wcag-overview', 'w3c-wai', 'procurement-accessibility'],
+    examTips: [
+      'Part A = tool UI is accessible; Part B = tool produces accessible content',
+      'ATAG is a W3C Recommendation with three conformance levels (A, AA, AAA)',
+      'Three WAI guidelines: WCAG (content), ATAG (authoring tools), UAAG (user agents)',
+      'ATAG currently references WCAG 2.0 — apply WCAG 2.1/2.2 criteria when evaluating',
+      'Examples of authoring tools: CMS, WYSIWYG editors, social media platforms, LMS'
+    ]
+  },
+
+  // ============================================================
+  // WAS-SPECIFIC: TESTING & EVALUATION
+  // ============================================================
+  {
+    slug: 'wcag-em',
+    title: 'WCAG-EM: Website Accessibility Conformance Evaluation Methodology',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'WCAG-EM defines a structured 5-step process for evaluating website accessibility: define scope, explore the website, select a representative sample, audit the sample, and report findings.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'The Website Accessibility Conformance Evaluation Methodology (WCAG-EM) 1.0 is a W3C Working Group Note that provides a structured approach for evaluating websites against WCAG. It is especially useful for large websites where testing every page is not feasible. WCAG-EM defines how to select a representative sample and conduct a reliable evaluation.'
+      },
+      {
+        type: 'heading',
+        text: 'The 5 Steps of WCAG-EM'
+      },
+      {
+        type: 'list',
+        items: [
+          'Step 1 — Define the evaluation scope: Identify the website scope (pages/states included), the WCAG conformance target level (A, AA, or AAA), and any specific browser/AT requirements',
+          'Step 2 — Explore the website: Identify key pages, key functionality, types of content (forms, tables, multimedia, dynamic widgets), required technologies, and common page templates',
+          'Step 3 — Select a representative sample: Choose a structured sample (pages representing key functionality and templates) plus a randomly selected sample; the sample must represent the website\'s full range of content and functionality',
+          'Step 4 — Audit the selected sample: Evaluate each page against all applicable WCAG Success Criteria; combine automated testing with manual evaluation; record successes, failures, and not-applicable results',
+          'Step 5 — Report the evaluation findings: Aggregate results; make conformance statements for each audited page; note that conformance is claimed per individual page, not for the entire website'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Key Principles'
+      },
+      {
+        type: 'list',
+        items: [
+          'WCAG conformance is at the individual page level — a strict conformance claim can only apply to pages that were actually tested',
+          'If any single Success Criterion fails on a page, that page does not conform',
+          'WCAG-EM does not define how to test individual Success Criteria — it defines the evaluation process and sampling methodology',
+          'The W3C provides a WCAG-EM Report Tool to assist auditors in generating structured evaluation reports',
+          'Sampling conclusions about the overall website are estimates, not strict conformance claims'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: WCAG-EM has 5 steps: Scope → Explore → Sample → Audit → Report. Conformance is per individual page — not per entire website. If any single SC fails, that page does not conform. WCAG-EM is for the evaluation process and sampling — it does NOT define how to test individual Success Criteria. A conforming alternate version must be equivalent in content and accessible itself.'
+      }
+    ],
+    relatedTopics: ['wcag-overview', 'testing-fundamentals', 'act-rules', 'automated-testing-tools'],
+    examTips: [
+      '5 steps: Define Scope → Explore Website → Select Sample → Audit Sample → Report Findings',
+      'Conformance is per page — if one SC fails, the page does not conform',
+      'Sample includes structured pages (key templates/functions) plus random pages',
+      'WCAG-EM defines the evaluation process, not how to test individual SC',
+      'A conforming alternate version must be equivalent and itself accessible',
+      'Use the WCAG-EM Report Tool to generate structured reports'
+    ]
+  },
+  {
+    slug: 'act-rules',
+    title: 'ACT Rules (Accessibility Conformance Testing)',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'ACT Rules standardize how individual accessibility tests are defined and executed, improving consistency across automated tools and manual testing methodologies.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'The Accessibility Conformance Testing (ACT) Rules are developed by a W3C community group of accessibility tool vendors, test authors, and experts. ACT Rules aim to harmonize the interpretation of WCAG and WAI-ARIA standards for testing purposes, leading to more consistent results across different tools and evaluators.'
+      },
+      {
+        type: 'heading',
+        text: 'What ACT Rules Are'
+      },
+      {
+        type: 'list',
+        items: [
+          'ACT Rules define specific, reproducible tests for individual aspects of WCAG Success Criteria',
+          'Each rule checks for a single type of failure — a Success Criterion typically has multiple ACT Rules covering its different aspects',
+          'Rules are primarily intended for tool developers and test methodology authors, not directly for content creators',
+          'ACT Rules are non-normative W3C resources — they are NOT required for determining WCAG conformance'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'ACT Rule Structure'
+      },
+      {
+        type: 'list',
+        items: [
+          'Applicability: defines which page elements the rule applies to (e.g., "all img elements with an alt attribute")',
+          'Expectations: defines what must be true for the element to pass the rule',
+          'Assumptions: states assumptions that affect the applicability or expectation',
+          'Each rule maps to one or more WCAG Success Criteria',
+          'Test cases: each rule includes passed, failed, and inapplicable example code'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Limitations of ACT Rules'
+      },
+      {
+        type: 'list',
+        items: [
+          'Passing an ACT Rule does NOT mean the corresponding SC is fully met — rules only check one specific aspect',
+          'Failing an ACT Rule means the content has a specific issue, but further manual review may still be needed for context',
+          'ACT Rules cannot assess content quality (e.g., whether alt text is meaningful, whether headings are descriptive)',
+          'Automated tools implement ACT Rules, but no tool covers all rules — and some rules require semi-automated or manual testing'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: ACT Rules check for specific failures — passing a rule does NOT mean full SC conformance. ACT Rules are non-normative and NOT required for WCAG conformance. Rules are for tool developers, not content creators. Each SC typically has multiple ACT Rules, each checking one aspect. Automated tools cannot determine full WCAG conformance — manual testing is always needed.'
+      }
+    ],
+    relatedTopics: ['wcag-em', 'automated-testing-tools', 'testing-fundamentals', 'wcag-overview'],
+    examTips: [
+      'ACT Rules check for specific failures — passing does NOT equal full SC conformance',
+      'Non-normative: NOT required for determining WCAG conformance',
+      'Primarily for tool developers and test methodology authors',
+      'Each rule has: applicability, expectations, assumptions, and test cases',
+      'No automated tool covers all ACT Rules — manual testing is always needed',
+      'ACT Rules standardize test interpretation for more consistent results across tools'
+    ]
+  },
+  {
+    slug: 'accessibility-qa-lifecycle',
+    title: 'Accessibility QA in the Development Lifecycle',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'Accessibility must be integrated throughout the entire product lifecycle — from planning through design, development, and testing — not bolted on at the end.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Accessibility quality assurance is most effective when integrated into every phase of the product lifecycle: Plan, Create, Test (PCT). Discovering and fixing accessibility issues early (shift-left testing) is far more cost-effective than remediating after release. Every team member — from management to designers, developers, content creators, and QA — has a role in delivering an accessible product.'
+      },
+      {
+        type: 'heading',
+        text: 'Plan Phase'
+      },
+      {
+        type: 'list',
+        items: [
+          'Include people with disabilities in user research',
+          'Define the target conformance level and applicable standards (WCAG 2.2, EN 301 549)',
+          'Include accessibility in the "Definition of Done" for all stories and tasks',
+          'Assign accessibility responsibilities to team members',
+          'Budget for accessibility training, expert consultation, and user testing with people with disabilities',
+          'Review the development environment: coding libraries, component libraries, and automated checks'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Create Phase'
+      },
+      {
+        type: 'list',
+        items: [
+          'Implement accessibility in information architecture and UX design',
+          'Address user needs including people with disabilities in all design decisions',
+          'Developers ensure code meets accessibility requirements using accessible patterns and components',
+          'Content creators produce accessible content: structured headings, meaningful alt text, descriptive links and labels',
+          'Design reviews should include accessibility checkpoints'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Test Phase'
+      },
+      {
+        type: 'list',
+        items: [
+          'Combine automated and manual testing — automated tools catch only 30-50% of issues',
+          'Test with assistive technologies (screen readers, keyboard-only, magnification)',
+          'Follow the applicable standard consistently throughout iterative development',
+          'Use a standard report structure for evaluation findings',
+          'Ensure accessibility bugs are fixed, reviewed, and do not regress',
+          'Track and communicate accessibility progress over time'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Agile vs. Waterfall'
+      },
+      {
+        type: 'list',
+        items: [
+          'Agile: accessibility is integrated into each sprint — test early and often; include a11y criteria in story acceptance requirements; iterate based on testing feedback',
+          'Waterfall: testing happens at the end of development — if issues are found late, they are more expensive and time-consuming to fix; tests may be rushed or omitted under time pressure',
+          'Agile is generally more effective for accessibility because it enables early discovery and iterative improvement'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: Plan–Create–Test (PCT) cycle. Shift-left = find issues early, when they are cheaper to fix. Automated tools catch only 30-50% of accessibility issues — manual testing is always required. In agile, accessibility is part of every sprint and the Definition of Done. In waterfall, late-stage testing is risky because time pressure leads to skipped or incomplete testing.'
+      }
+    ],
+    relatedTopics: ['testing-fundamentals', 'automated-testing-tools', 'wcag-em', 'remediation-prioritization'],
+    examTips: [
+      'Plan–Create–Test cycle: accessibility is part of every phase',
+      'Shift-left: find issues early when they are cheaper to fix',
+      'Every team member has a role in accessibility — not just QA',
+      'Automated tools catch 30-50% of issues — manual testing always required',
+      'Agile: accessibility in every sprint and Definition of Done',
+      'Waterfall: late-stage testing is risky — issues are more expensive to fix'
+    ]
+  },
+
+  // ============================================================
+  // WAS-SPECIFIC: REMEDIATION
+  // ============================================================
+  {
+    slug: 'remediation-prioritization',
+    title: 'Remediation Prioritization & Severity',
+    category: 'Remediation',
+    applicableTo: ['was'],
+    summary: 'Not all accessibility issues are equally critical. Prioritize by user impact, frequency of occurrence, legal risk, and cost-benefit — fix blocking issues on high-traffic flows first.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Accessibility audits often reveal many issues that cannot all be fixed at once. Effective remediation requires prioritizing issues based on their severity and impact. The goal is to allocate limited resources to maximize accessibility improvement, especially when the website or app is already in production.'
+      },
+      {
+        type: 'heading',
+        text: 'Prioritization Factors'
+      },
+      {
+        type: 'list',
+        items: [
+          'User impact: High-impact issues block users entirely (e.g., no keyboard access, CAPTCHAs without alternatives, content hidden from screen readers). Medium-impact issues make tasks difficult but not impossible. Low-impact issues cause minor inconvenience',
+          'Frequency: Issues in templates, component libraries, or design systems multiply across the entire site — fixing them once fixes many pages. EN 301 549 Annex B maps requirements to user needs, helping determine impact breadth',
+          'Key content and tasks: Prioritize pages and flows with the highest traffic — often 20% of pages receive 90% of traffic. Critical user flows like registration, search, and checkout should be fixed first',
+          'Cost-benefit: Some fixes are quick and high-impact (adding alt text, fixing form labels); others require major redesign with less immediate user benefit',
+          'Legal risk: Issues violating legally mandated standards (e.g., Level A or AA failures) carry higher legal risk than best-practice recommendations',
+          'WCAG conformance level: Level A failures are generally more severe than AA, which are more severe than AAA recommendations'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Prioritization Strategy'
+      },
+      {
+        type: 'list',
+        items: [
+          'Fix high-impact issues on high-traffic pages first',
+          'Address template-level and component-library issues early — they affect many pages at once',
+          'Tackle low-effort, high-impact fixes immediately (e.g., missing alt text, missing form labels, color contrast)',
+          'Plan longer-term redesign for systemic issues that require architectural changes',
+          'Establish a process for avoiding new barriers — integrate accessibility into the Definition of Done'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: Prioritize by: user impact (blocking > difficult > minor), frequency (template issues multiply site-wide), key flows (high-traffic pages first), cost-benefit (quick fixes first), and legal risk (Level A > AA > AAA). Fix template/component issues early because they propagate. EN 301 549 Annex B maps requirements to user groups, helping assess impact.'
+      }
+    ],
+    relatedTopics: ['remediation-strategies', 'wcag-overview', 'wcag-em', 'accessibility-qa-lifecycle'],
+    examTips: [
+      'Prioritize: high user impact + high traffic + low effort = fix first',
+      'Template/component-level issues multiply across the site — fix early',
+      'Level A failures are generally more severe than AA',
+      'EN 301 549 Annex B maps requirements to user needs for impact analysis',
+      '20% of pages often receive 90% of traffic — focus remediation there',
+      'Establish processes to prevent new barriers, not just fix old ones'
+    ]
+  },
+  {
+    slug: 'remediation-strategies',
+    title: 'Remediation Strategies',
+    category: 'Remediation',
+    applicableTo: ['was'],
+    summary: 'Remediation ranges from quick fixes (adding alt text, fixing labels) to complete redesign. Choose the approach based on severity, code complexity, available resources, and long-term sustainability.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Recommending effective remediation strategies requires understanding how to create accessible content (Domain 1), identifying issues accurately (Domain 2), and choosing appropriate fixes for the specific context. The approach depends on the severity of defects, code complexity, available resources, and the need for long-term sustainability.'
+      },
+      {
+        type: 'heading',
+        text: 'Fixing vs. Redesign'
+      },
+      {
+        type: 'list',
+        items: [
+          'Fixing: targeted repairs to specific issues without changing the overall design — appropriate for localized, minor defects',
+          'Redesign: rebuilding a component or page section from scratch — necessary when defects are widespread, deeply embedded in the architecture, or in templates/design systems',
+          'Hybrid approach: immediately fix critical blockers while planning a longer-term redesign for systemic issues',
+          'Consider: is the current code maintainable? Older, complex code may make fixing harder and more fragile than rewriting',
+          'A rewrite can incorporate current best practices and be more future-proof, but requires more resources'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Failures vs. Best Practices'
+      },
+      {
+        type: 'list',
+        items: [
+          'A conformance failure clearly violates a WCAG Success Criterion — it must be fixed to achieve conformance',
+          'A best practice issue makes the experience suboptimal but does not technically fail a specific SC — it should still be recommended for better usability',
+          'Auditors must clearly communicate the distinction: "This fails SC 1.1.1" vs. "This is a usability concern but not a WCAG failure"',
+          'WCAG Sufficient Techniques are informative, not normative — there may be valid approaches not documented as techniques'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Common Remediation Patterns'
+      },
+      {
+        type: 'list',
+        items: [
+          'Missing alt text: add descriptive alt for informative images; alt="" for decorative images',
+          'Missing form labels: associate <label> elements via for/id or wrapping; use aria-label for icon-only controls',
+          'Keyboard access: ensure all interactive elements are reachable and operable via keyboard; remove tabindex values greater than 0',
+          'Color contrast: adjust foreground/background colors to meet 4.5:1 (text) or 3:1 (large text, UI components) ratios',
+          'Heading structure: ensure logical heading hierarchy (h1 → h2 → h3); do not skip levels for visual styling',
+          'ARIA patches: add ARIA roles, states, and properties to existing elements without full refactoring — use as a bridge to a proper semantic rewrite',
+          'Focus management: add visible focus indicators; manage focus on dynamic content changes'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: Know the difference between a conformance failure (fails a specific SC — must be fixed) and a best practice (improves usability but not a WCAG failure). ARIA patches can fix issues without full redesign, but semantic HTML is always preferred long-term. A hybrid approach works: fix critical blockers immediately while planning redesign for systemic issues. Communicate findings precisely: which SC fails, where, and how to fix it.'
+      }
+    ],
+    relatedTopics: ['remediation-prioritization', 'semantic-html', 'aria-overview', 'form-accessibility', 'color-contrast'],
+    examTips: [
+      'Conformance failure = violates a WCAG SC; best practice = improves UX but not a formal failure',
+      'ARIA patches can fix issues without redesign, but semantic HTML is preferred long-term',
+      'Hybrid approach: fix critical blockers immediately, plan redesign for systemic issues',
+      'Communicate clearly: which SC fails, where on the page, and how to fix it',
+      'Sufficient Techniques are informative, not normative — other valid approaches exist',
+      'Consider code complexity and maintainability when choosing fix vs. redesign'
+    ]
+  },
+
+  // ============================================================
+  // WAS-SPECIFIC: USER STRATEGIES
+  // ============================================================
+  {
+    slug: 'disability-user-strategies',
+    title: 'How Users with Disabilities Navigate the Web',
+    category: 'Assistive Technology',
+    applicableTo: ['was'],
+    summary: 'Different disability groups use distinct strategies and assistive technologies to navigate the web. Understanding these strategies is essential for creating, testing, and remediating accessible content.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'People with disabilities use a wide range of strategies, assistive technologies, and adaptive configurations to access web content. Understanding these approaches is fundamental to the WAS exam — it informs how you create accessible content, what you test for, and how you prioritize remediation. Strategies vary considerably even within a single disability group based on individual experience and technology expertise.'
+      },
+      {
+        type: 'heading',
+        text: 'Users Without Vision (Blind)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Primary AT: screen readers (JAWS, NVDA on Windows; VoiceOver on macOS/iOS; TalkBack on Android)',
+          'Navigation strategies: jump by headings, landmarks, links, form controls, or tables using screen reader keyboard shortcuts',
+          'Screen readers present content linearly following DOM order — visual layout is irrelevant',
+          'Modes: Browse/Read mode (navigate by element), Forms mode (type in form fields), Application mode (widget keyboard patterns)',
+          'Mobile: completely different gesture-based interaction model — swipe right/left to move forward/back, double-tap to activate',
+          'Refreshable Braille displays may be used for reading output instead of or alongside speech'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Users with Low Vision'
+      },
+      {
+        type: 'list',
+        items: [
+          'Strategies range from browser zoom (moderate vision loss) to dedicated magnification software (severe vision loss)',
+          'Magnification software: ZoomText, Fusion (JAWS + magnification), built-in OS magnifiers — up to 60x (6000%) zoom',
+          'Often combine magnification with screen reader speech output for orientation and reading longer text',
+          'Orientation challenges at high magnification — users zoom out for overview, zoom in for detail',
+          'May use high contrast modes (Windows High Contrast Mode), custom colors, enlarged cursors, and modified focus indicators',
+          'Focus tracking is important: the visible portion of content must follow keyboard and pointer focus'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Users with Motor Disabilities'
+      },
+      {
+        type: 'list',
+        items: [
+          'Keyboard-only users: navigate sequentially with Tab/Shift+Tab; cannot jump to headings or landmarks like screen reader users',
+          'Switch device users: simulate Tab navigation with single switch input; large, clearly visible targets are essential',
+          'Voice control users (Dragon, Voice Control): say "Click [label text]" to activate controls — the visible label must match the accessible name',
+          'Head pointers, mouth sticks, eye trackers: need large click targets and adequate spacing between targets',
+          'Skip navigation links are critical since keyboard-only users cannot navigate by headings or landmarks',
+          'Prediction and autofill reduce the number of keystrokes needed for text input'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Users with Cognitive Disabilities'
+      },
+      {
+        type: 'list',
+        items: [
+          'This is a very diverse group: ADHD, dyslexia, autism, memory loss, intellectual disabilities, neurological conditions',
+          'Clear, simple language and consistent, predictable navigation are essential',
+          'May use text-to-speech (not full screen readers) to help with reading comprehension',
+          'Custom stylesheets, ad blockers, and screen masking tools to reduce distractions',
+          'Autocomplete attributes on form fields help users fill in data with less cognitive effort',
+          'Content alternatives (images, video, audio) alongside text help users who struggle with text-only content'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Users with Auditory Disabilities'
+      },
+      {
+        type: 'list',
+        items: [
+          'Do not typically use assistive technology — rely on visual alternatives for audio content',
+          'Pre-recorded audio: transcripts are required (SC 1.2.1 Level A)',
+          'Pre-recorded and live video: captions are required (SC 1.2.2 Level A, SC 1.2.4 Level AA)',
+          'Deaf sign language users: written text can be difficult — sign language videos are helpful (SC 1.2.6, Level AAA)',
+          'Automatic captions must be reviewed and corrected — AI-generated captions contain errors',
+          'Closed captions (can be shown/hidden) are preferred over open captions (burned in) because they are customizable'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam tip: Blind users navigate by headings, landmarks, and links. Keyboard-only users (motor disabilities) can only Tab sequentially — they CANNOT jump by headings/landmarks. Voice control users need visible labels that match accessible names (SC 2.5.3). Low vision users may combine magnification with screen reader speech. Deaf sign language users may find written text difficult — it is like a second language. Screen reader modes: Browse, Forms, Application.'
+      }
+    ],
+    relatedTopics: ['screen-readers', 'switch-devices', 'visual-disabilities', 'cognitive-disabilities', 'mobility-disabilities', 'auditory-disabilities'],
+    examTips: [
+      'Blind: screen readers, navigate by headings/landmarks/links, content is linear per DOM order',
+      'Low vision: magnification + possibly screen reader, zoom out/in for orientation, need focus tracking',
+      'Motor: keyboard-only users Tab sequentially — cannot jump by headings like SR users; voice control needs matching labels',
+      'Cognitive: simple language, consistent navigation, text-to-speech (not full SR), autocomplete for forms',
+      'Deaf: captions, transcripts, sign language videos; closed captions preferred over open; fix auto-caption errors',
+      'Screen reader modes: Browse/Read mode, Forms mode, Application mode'
     ]
   }
 ];

--- a/src/data/knowledgeBase/index.js
+++ b/src/data/knowledgeBase/index.js
@@ -1465,18 +1465,60 @@ export const topics = [
       },
       {
         type: 'paragraph',
-        text: 'UDL is based on neuroscience research identifying three brain networks: affective (engagement/motivation), recognition (pattern recognition/comprehension), and strategic (planning/execution). Each UDL principle corresponds to one of these networks.'
+        text: 'UDL is based on neuroscience research identifying three brain networks, and each UDL principle corresponds to one of them. The affective network (the "why" of learning) handles motivation and emotional engagement. The recognition network (the "what" of learning) handles how we perceive and categorize information. The strategic network (the "how" of learning) handles goal-setting, planning, action, and monitoring — the network behind Action and Expression.'
+      },
+      {
+        type: 'heading',
+        text: 'Principle 1 — Engagement (Affective Network / WHY)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Provide options for recruiting interest — offer choice, ensure relevance/authenticity, minimize threats and distractions',
+          'Provide options for sustaining effort and persistence — highlight goals, vary challenge levels, foster collaboration, increase mastery-oriented feedback',
+          'Provide options for self-regulation — promote expectations, develop coping skills, support self-assessment and reflection'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Principle 2 — Representation (Recognition Network / WHAT)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Provide options for perception — customize display of information, offer alternatives for auditory info (captions, transcripts), offer alternatives for visual info (alt text, descriptions)',
+          'Provide options for language and symbols — clarify vocabulary, clarify syntax, support decoding, promote cross-language understanding, illustrate through multiple media',
+          'Provide options for comprehension — activate background knowledge, highlight patterns and relationships, guide information processing, maximize transfer and generalization'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Principle 3 — Action and Expression (Strategic Network / HOW)'
+      },
+      {
+        type: 'paragraph',
+        text: 'Action and Expression is the UDL principle most often confused with Engagement on the exam because it deals with what the learner does. The distinction: Engagement is about motivation (the "why"), while Action and Expression is about how learners physically interact with materials, how they express or communicate what they know, and how they plan and monitor their learning. It is tied to the strategic brain network.'
+      },
+      {
+        type: 'list',
+        items: [
+          'Provide options for physical action — vary the methods for response and navigation, optimize access to tools and assistive technologies (keyboards, switches, voice input, alternate pointing devices)',
+          'Provide options for expression and communication — use multiple media for communication, use multiple tools for construction and composition (essays, video, slides, models), build fluencies with graduated levels of support',
+          'Provide options for executive functions — guide appropriate goal-setting, support planning and strategy development, facilitate managing information and resources, enhance capacity for monitoring progress'
+        ]
       },
       {
         type: 'callout',
-        text: 'Exam tip: Know the three UDL principles: Engagement (WHY), Representation (WHAT), Action/Expression (HOW). UDL was developed by CAST. UDL is specifically about learning and education — do not confuse it with the 7 Principles of Universal Design (which are about product/environment design in general).'
+        text: 'Exam tip: On questions that ask which UDL principle applies, use the brain network shortcut. Affective → Engagement (why/motivation). Recognition → Representation (what/perception and comprehension). Strategic → Action and Expression (how/physical action, expression, executive function). If the scenario involves how a learner produces or demonstrates their learning — writing an essay vs. recording a video, using a switch device, planning a project — that is Action and Expression, not Engagement.'
       }
     ],
     relatedTopics: ['universal-design-principles', 'cognitive-disabilities', 'accessibility-vs-accommodation'],
     examTips: [
       'Three principles: Engagement (WHY), Representation (WHAT), Action/Expression (HOW)',
-      'Developed by CAST (Center for Applied Special Technology)',
-      'Based on neuroscience: affective, recognition, and strategic brain networks',
+      'Three brain networks: Affective → Engagement, Recognition → Representation, Strategic → Action/Expression',
+      'Action and Expression covers physical action, expression/communication, and executive functions (goal-setting, planning, monitoring)',
+      'Engagement is about motivation ("why") — do not confuse it with Action/Expression ("how")',
+      'Developed by CAST (Center for Applied Special Technology); current framework is UDL Guidelines 3.0',
       'UDL = education-specific; UD = general product/environment design'
     ]
   },
@@ -1485,11 +1527,11 @@ export const topics = [
     title: 'Accessibility in the Built Environment',
     category: 'Universal Design',
     applicableTo: ['cpacc', 'was'],
-    summary: 'Physical space accessibility including ramps, elevators, signage, wayfinding, and building design that accommodates all users.',
+    summary: 'Physical space accessibility including floor surfaces, accessible routes, ramps, elevators, signage, and wayfinding.',
     content: [
       {
         type: 'paragraph',
-        text: 'Accessibility in the built environment refers to making physical spaces — buildings, streets, parks, transportation systems — usable by people with all types of disabilities. While the CPACC exam is primarily focused on digital accessibility, it includes content on the built environment because physical and digital accessibility are interconnected. A person who cannot physically enter a building is as excluded as a person who cannot navigate a website.'
+        text: 'Accessibility in the built environment means making physical spaces — buildings, streets, parks, transportation systems — usable by people with all types of disabilities. While CPACC is primarily a digital accessibility exam, it includes built-environment content because physical and digital accessibility are interconnected. A person who cannot physically enter a building is as excluded as a person who cannot navigate a website. In the US, the ADA Standards for Accessible Design (2010) are the authoritative reference, and many of their specific measurements appear on the exam.'
       },
       {
         type: 'heading',
@@ -1498,12 +1540,55 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'Entrances and exits: Ramps, automatic doors, level thresholds, adequate width for wheelchairs',
-          'Vertical circulation: Elevators, accessible stairways with handrails, ramps between levels',
-          'Wayfinding and signage: Tactile signage (braille, raised text), visual contrast, clear directional signs, tactile ground surface indicators',
-          'Restrooms: Accessible stalls with grab bars, adequate turning space, accessible fixtures',
-          'Parking: Accessible parking spaces with proper dimensions and proximity to entrances',
-          'Lighting and acoustics: Adequate lighting for lip-reading, hearing loop systems, reduced echo for hearing aid users'
+          'Entrances and exits: ramps, automatic doors, level thresholds, adequate width for wheelchairs',
+          'Vertical circulation: elevators, accessible stairways with handrails, ramps between levels',
+          'Wayfinding and signage: tactile signage (braille, raised text), visual contrast, clear directional signs, tactile ground surface indicators (truncated domes)',
+          'Restrooms: accessible stalls with grab bars, adequate turning space, accessible fixtures',
+          'Parking: accessible parking spaces with proper dimensions and proximity to entrances',
+          'Lighting and acoustics: adequate lighting for lip-reading, hearing loop (induction loop) systems, reduced echo for hearing aid users'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Floor and Ground Surfaces (ADA §302)'
+      },
+      {
+        type: 'paragraph',
+        text: 'ADA Standards §302.1 specifies that accessible floor and ground surfaces must be stable, firm, and slip-resistant. This three-word requirement is a classic exam answer. "Stable" means the surface does not move or shift under load; "firm" means it does not compress or deform significantly; "slip-resistant" means it provides adequate friction so people using canes, crutches, walkers, or wheelchairs do not slip.'
+      },
+      {
+        type: 'list',
+        items: [
+          '§302.1 — All accessible floor and ground surfaces must be stable, firm, and slip-resistant',
+          '§302.2 Carpet — If carpet is used, pile height is limited to 1/2 inch (measured to the backing, cushion, or pad). Carpet must be securely attached with a firm backing; exposed edges must be fastened and trimmed',
+          '§302.3 Openings — Openings in floor or ground surfaces must not allow passage of a 1/2 inch diameter sphere (prevents cane tips and small wheels from catching). Elongated openings must be oriented perpendicular to the dominant direction of travel'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Changes in Level (ADA §303)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Changes in level up to 1/4 inch high may be vertical (no treatment required)',
+          'Changes in level between 1/4 inch and 1/2 inch must be beveled with a slope no steeper than 1:2',
+          'Changes in level greater than 1/2 inch must be treated as a ramp or curb ramp (see §405)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Accessible Routes and Ramps (ADA §402, §403, §405)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Accessible route minimum clear width: 36 inches (§403.5). Width may be reduced to 32 inches minimum at a point (for example, a doorway) for a maximum length of 24 inches',
+          'Ramp maximum running slope: 1:12 (§405.2) — one inch of rise for every twelve inches of run',
+          'Ramp maximum rise per single run: 30 inches (§405.6). Longer ramps require intermediate landings',
+          'Ramp minimum clear width: 36 inches between handrails (§405.5)',
+          'Handrails are required on both sides of ramps with a rise greater than 6 inches (§405.8)',
+          'Level landings are required at the top and bottom of each ramp run, and where ramps change direction'
         ]
       },
       {
@@ -1513,23 +1598,28 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'ADA Standards for Accessible Design (USA)',
+          'ADA Standards for Accessible Design (USA, 2010) — authoritative US requirements',
           'ISO 21542: Building construction — Accessibility and usability of the built environment',
+          'EN 17210: European accessibility and usability of the built environment (functional requirements)',
           'Local building codes and accessibility regulations vary by country',
-          'Universal Design principles apply to built environment design'
+          'Universal Design principles apply to built environment design broadly'
         ]
       },
       {
         type: 'callout',
-        text: 'Exam tip: Built environment questions are less common than digital accessibility questions, but know the basics: ramps, elevators, tactile signage with braille, hearing loops, accessible parking. The connection between physical and digital accessibility is important — both are needed for full inclusion.'
+        text: 'Exam tip: Memorize §302 — floor and ground surfaces must be stable, firm, and slip-resistant. This is a recurring exam question. Also remember carpet pile ≤ 1/2 inch, ramp slope max 1:12, single ramp rise max 30 inches, and accessible route clear width 36 inches (reducible to 32" at doorways).'
       }
     ],
     relatedTopics: ['universal-design-principles', 'ada', 'mobility-disabilities'],
     examTips: [
-      'Know basic built environment features: ramps, elevators, braille signage, hearing loops',
-      'Tactile ground surface indicators (detectable warnings) are truncated dome patterns',
-      'Physical and digital accessibility are both needed for full inclusion',
-      'ADA Standards for Accessible Design govern US built environment accessibility'
+      'ADA §302: accessible floor and ground surfaces must be stable, firm, and slip-resistant',
+      'ADA §302.2: carpet pile height max 1/2 inch, securely attached, firm backing',
+      'ADA §302.3: floor openings must not pass a 1/2 inch sphere',
+      'ADA §303: level changes ≤1/4" untreated, 1/4"–1/2" beveled 1:2, >1/2" ramped',
+      'ADA §405: ramp slope max 1:12, single run rise max 30", clear width 36" min',
+      'Accessible route clear width: 36 inches minimum (32 inches allowable at a doorway)',
+      'Tactile ground surface indicators (detectable warnings) use truncated dome patterns',
+      'Physical and digital accessibility are both needed for full inclusion'
     ]
   },
 
@@ -1880,28 +1970,61 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'Title I — Employment: Prohibits discrimination in hiring, firing, advancement, and compensation by employers with 15+ employees. Requires reasonable accommodations.',
-          'Title II — Public Services (State and Local Government): Requires state and local governments to make their services, programs, and activities accessible. Includes government websites.',
-          'Title III — Public Accommodations (Private Businesses): Requires businesses open to the public to be accessible. Has been applied to websites through court rulings.',
-          'Title IV — Telecommunications: Requires telephone companies to provide relay services for deaf and hard of hearing users.',
-          'Title V — Miscellaneous: Includes anti-retaliation provisions and the relationship to other laws.'
+          'Title I — Employment: Prohibits discrimination in hiring, firing, advancement, and compensation by employers with 15 or more employees. Requires reasonable accommodations unless they cause "undue hardship." Enforced by the EEOC.',
+          'Title II — Public Services (State and Local Government): Requires state and local governments and their entities (public schools, libraries, DMVs, police, public transit) to make their programs, services, and activities accessible. Applies regardless of whether the entity receives federal funding. Now explicitly references WCAG 2.1 AA for web and mobile content (DOJ 2024 rule).',
+          'Title III — Public Accommodations (Private Businesses Open to the Public): Requires privately-operated places of public accommodation — restaurants, hotels, retail stores, theaters, doctor\'s offices, private schools, gyms — to be accessible. Has been extended to many commercial websites through court rulings.',
+          'Title IV — Telecommunications: Required telephone companies to provide telecommunications relay services (TRS) for people who are deaf, hard of hearing, or have speech disabilities. Enforced by the FCC.',
+          'Title V — Miscellaneous: Contains anti-retaliation provisions, attorney\'s fees provisions, and clarifies the ADA\'s relationship to other laws (including state laws that provide greater protection).'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Scenario-to-Title Quick Reference'
+      },
+      {
+        type: 'list',
+        items: [
+          'A job applicant is denied reasonable accommodation during an interview → Title I (Employment)',
+          'A city refuses to provide sign language interpretation at a public council meeting → Title II (State/Local Government)',
+          'A public library\'s website is not screen reader accessible → Title II',
+          'A restaurant has no ramp at its only entrance → Title III (Public Accommodations)',
+          'A national retailer\'s e-commerce site is not keyboard accessible → Title III (typically, depending on circuit)',
+          'A telephone company does not provide relay services for deaf callers → Title IV (Telecommunications)',
+          'An employee is fired for filing an ADA complaint → Title V (anti-retaliation)',
+          'Key distinction: Title II = government/public entity; Title III = private business open to the public'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Key Defenses and Limits'
+      },
+      {
+        type: 'list',
+        items: [
+          '"Undue hardship" — an employer may deny an accommodation under Title I if providing it would cause significant difficulty or expense relative to the employer\'s size and resources',
+          '"Fundamental alteration" — a public entity or business is not required to make a change that would fundamentally alter the nature of its program, service, or goods',
+          '"Readily achievable" — Title III only requires barrier removal in existing facilities when it is readily achievable (easily accomplishable without much difficulty or expense)'
         ]
       },
       {
         type: 'paragraph',
-        text: 'The ADA does not explicitly mention websites or digital accessibility (it was written in 1990), but courts have increasingly interpreted Titles II and III to apply to websites and digital services. The Department of Justice issued a rule in 2024 requiring state and local government websites to conform to WCAG 2.1 Level AA under Title II. Title III web accessibility requirements for private businesses continue to be shaped by court rulings.'
+        text: 'The ADA does not explicitly mention websites or digital accessibility (it was written in 1990), but courts have increasingly interpreted Titles II and III to apply to websites and digital services. The Department of Justice issued a rule in 2024 requiring state and local government websites and mobile apps to conform to WCAG 2.1 Level AA under Title II. Title III web accessibility requirements for private businesses continue to be shaped by court rulings, with most circuits applying the ADA to websites tied to physical places of business and some applying it to purely online businesses as well.'
       },
       {
         type: 'callout',
-        text: 'Exam tip: Know the five ADA titles, especially Title I (employment), Title II (government), and Title III (public accommodations/businesses). The ADA was signed in 1990. It does not explicitly mention websites but has been applied to digital accessibility through court interpretations. Title II now references WCAG 2.1 AA for government websites. The ADA is a civil rights law, not a technology standard.'
+        text: 'Exam tip: Memorize the scenario-to-Title mapping. Title I = employment (15+ employees). Title II = state/local government entities (libraries, DMVs, public schools, public transit). Title III = private businesses open to the public (restaurants, stores, hotels). Title IV = relay services. Title V = anti-retaliation, attorney\'s fees, relationship to state laws. "Undue hardship" is the Title I defense; "readily achievable" is the Title III standard for barrier removal in existing facilities.'
       }
     ],
-    relatedTopics: ['section-508', 'cvaa', 'crpd', 'national-disability-laws'],
+    relatedTopics: ['section-508', 'cvaa', 'crpd', 'national-disability-laws', 'built-environment'],
     examTips: [
-      'Signed July 26, 1990 — know the five titles',
-      'Title I = Employment (15+ employees), Title II = Government, Title III = Public Accommodations',
-      'Does not explicitly mention websites — applied through court interpretation',
-      'Title II now references WCAG 2.1 AA for government websites',
+      'Signed July 26, 1990 — know the five titles and which scenarios each covers',
+      'Title I = Employment (15+ employees); defense = "undue hardship"',
+      'Title II = State/Local Government (libraries, DMVs, public schools, public transit, government websites)',
+      'Title III = Public Accommodations (restaurants, retail, hotels); existing-facility standard = "readily achievable"',
+      'Title IV = Telecommunications Relay Services (TRS) — FCC enforced',
+      'Title V = anti-retaliation, attorney\'s fees, relationship to state laws',
+      'Title II vs III — the key distinction is government entity vs private business',
+      'Title II DOJ 2024 rule explicitly requires WCAG 2.1 AA for web and mobile',
       'A civil rights law, not a technology standard'
     ]
   },
@@ -2041,16 +2164,33 @@ export const topics = [
         ]
       },
       {
+        type: 'heading',
+        text: 'Related European Instruments'
+      },
+      {
+        type: 'paragraph',
+        text: 'Beyond the Web Accessibility Directive and the European Accessibility Act, two other European instruments often appear as exam distractors or correct answers and are worth knowing by name.'
+      },
+      {
+        type: 'list',
+        items: [
+          'EN 17161:2019 — "Design for All — Accessibility following a Design for All approach in products, goods and services — Extending the range of users." Published by CEN in 2019. Unlike EN 301 549 (which is a technical ICT standard), EN 17161 is a process/management standard: it specifies requirements for how an organization should embed a Design for All approach into its development, procurement, and service delivery to reach the widest possible range of users, including people with disabilities. It is generic and applies regardless of organization size or sector, and it is sometimes adopted as a framework for continuous improvement of accessibility',
+          'eIDAS — Regulation (EU) No 910/2014 on electronic identification and trust services for electronic transactions in the EU internal market. Entered into force in 2014 and became applicable in 2016. eIDAS is not primarily an accessibility law; it governs electronic identification (eID), electronic signatures, seals, timestamps, and qualified trust services for cross-border digital public services. The 2024 amendment (Regulation 2024/1183) introduced the European Digital Identity Wallet. Accessibility of eID means for persons with disabilities is expected via the horizontal accessibility requirements of the EAA and EN 301 549'
+        ]
+      },
+      {
         type: 'callout',
-        text: 'Exam tip: Know the difference: Web Accessibility Directive (2016) = public sector websites/apps; European Accessibility Act (2019, effective 2025) = private sector products/services. Both reference EN 301 549 which incorporates WCAG 2.1 AA. The WAD requires accessibility statements. The EAA is significant because it extends to the private sector.'
+        text: 'Exam tip: If you see "EN 17___" in options, it is usually EN 17161 (Design for All, a process standard). If you see "eI___" in options, it is usually eIDAS (Regulation 910/2014 on electronic identification and trust services). Do not confuse these with EN 301 549, which is the technical ICT accessibility standard that incorporates WCAG.'
       }
     ],
-    relatedTopics: ['en-301-549', 'wcag-overview', 'crpd', 'national-disability-laws'],
+    relatedTopics: ['en-301-549', 'wcag-overview', 'crpd', 'national-disability-laws', 'universal-design-principles'],
     examTips: [
-      'Web Accessibility Directive (2016) = public sector; European Accessibility Act (2019) = private sector',
+      'Web Accessibility Directive (2016) = public sector; European Accessibility Act (2019, effective June 28 2025) = private sector',
       'Both reference EN 301 549, which incorporates WCAG 2.1 AA',
       'WAD requires accessibility statements on public sector websites',
-      'EAA compliance required by June 28, 2025'
+      'EN 17161:2019 = Design for All process/management standard (CEN)',
+      'eIDAS = Regulation 910/2014 on electronic identification and trust services (not primarily an accessibility law)',
+      'EN 17161 is process-focused; EN 301 549 is technically-focused — both can appear as EU standard answers'
     ]
   },
   {
@@ -2494,26 +2634,96 @@ export const topics = [
     title: 'Disability Demographics & Statistics',
     category: 'Etiquette & Demographics',
     applicableTo: ['cpacc', 'was'],
-    summary: 'Key statistics about disability prevalence worldwide and the business case for accessibility.',
+    summary: 'Key statistics about disability prevalence worldwide, organized by disability category, and the business case for accessibility.',
     content: [
       {
         type: 'paragraph',
-        text: 'Understanding disability demographics helps establish the scope and importance of accessibility. Disability is far more common than many people realize, and the numbers are growing due to aging populations and improved diagnosis. These statistics also form the foundation of the business case for accessibility — when over a billion people worldwide have disabilities, accessibility is not a niche concern but a mainstream market need.'
+        text: 'Understanding disability demographics helps establish the scope and importance of accessibility. Disability is far more common than many people realize, and the numbers are growing due to aging populations, longer life expectancy, and better diagnosis. These statistics also form the foundation of the business case for accessibility — when over a billion people worldwide have disabilities, accessibility is not a niche concern but a mainstream market need.'
       },
       {
         type: 'heading',
-        text: 'Global Statistics'
+        text: 'Global & Regional Baselines'
       },
       {
         type: 'list',
         items: [
-          'WHO: Approximately 1.3 billion people (about 16% of the global population) have a significant disability',
-          'Disability prevalence increases with age — as populations age, disability prevalence grows',
-          'In the US, approximately 26% of adults (1 in 4) have some type of disability (CDC)',
-          'Cognitive disabilities are the most common type of disability globally',
-          'Approximately 2.2 billion people have a vision impairment (WHO)',
-          'Approximately 430 million people have disabling hearing loss (WHO)',
-          'Disability intersects with poverty — people with disabilities are disproportionately affected by poverty'
+          'Global (WHO, 2023 fact sheet): ~1.3 billion people — about 16% of the world population, or roughly 1 in 6 — experience a significant disability',
+          'European Union (Eurostat EU-SILC, 2022): more than one-quarter (>25%) of the EU population aged 16 and over reports a disability (activity limitation) — commonly cited as roughly 27%',
+          'United States (CDC): approximately 26% of adults — 1 in 4 — have some type of disability',
+          'Low- and middle-income countries generally have higher prevalence due to aging populations, conflict, and less-treated chronic conditions',
+          'Disability prevalence grows with age — for EU residents aged 85+, over 76% report a disability (Eurostat 2022)'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Exam strategy: pay attention to the category keyword in the question stem. A question that says "this neurological condition affects ~50 million people" is pointing at epilepsy; "this sensory impairment affects ~430 million" is pointing at disabling hearing loss. Reading the category label is a reliable elimination strategy.'
+      },
+      {
+        type: 'heading',
+        text: 'Sensory Disabilities'
+      },
+      {
+        type: 'list',
+        items: [
+          'Vision impairment: ~2.2 billion people globally have a near or distance vision impairment (WHO) — this is the headline sensory number',
+          'Disabling hearing loss: ~430 million people require rehabilitation today (WHO), including about 34 million children',
+          'Hearing loss projections: by 2050, nearly 2.5 billion people are projected to have some degree of hearing loss, with more than 700 million requiring rehabilitation',
+          'Deaf-blindness is counted as a distinct sensory category requiring tactile communication methods'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Neurological Conditions'
+      },
+      {
+        type: 'list',
+        items: [
+          'Epilepsy: ~50 million people worldwide live with epilepsy (WHO). Nearly 80% live in low- and middle-income countries. When an exam question mentions "a neurological condition affecting ~50 million," it is pointing at epilepsy',
+          'Stroke: ~15 million people have a stroke each year (WHO), and about 5 million are left with permanent disability',
+          'Migraine: widespread, and the leading cause of disability globally among people under age 50',
+          'Other neurological conditions tested on CPACC include Parkinson\'s disease, multiple sclerosis (MS), cerebral palsy (which also counts as motor), Huntington\'s disease, and traumatic brain injury'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Cognitive & Neurodevelopmental'
+      },
+      {
+        type: 'list',
+        items: [
+          'Cognitive disabilities (broad category) are the most common type of disability globally',
+          'Autism spectrum disorder: WHO (2021 data) estimates ~1 in 127 people has autism — older sources cite ~1 in 100 children, and CDC US figures are higher (~1 in 36 children as of recent ADDM data)',
+          'Intellectual disability: ~1% global prevalence',
+          'ADHD: ~5–10% of children',
+          'Dyslexia: ~5–10% of the population (a learning disability under the cognitive umbrella)',
+          'Down syndrome: ~1 in 700 births (a genetic condition causing intellectual disability)',
+          'Dementia: ~57 million people worldwide in 2021 (WHO), with nearly 10 million new cases per year and over 60% living in low- and middle-income countries'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Mental Health / Psychiatric Conditions'
+      },
+      {
+        type: 'list',
+        items: [
+          'Depression: WHO estimates ~5.7% of adults globally experience depression — on the order of several hundred million people',
+          'Anxiety disorders: among the most prevalent mental health conditions worldwide',
+          'Schizophrenia: ~24 million people globally (WHO)',
+          'Mental health conditions are often episodic, which affects how accommodations are designed and timed'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Motor / Physical Disabilities'
+      },
+      {
+        type: 'list',
+        items: [
+          'Spinal cord injury: ~250,000 to 500,000 new cases each year globally (WHO)',
+          'Arthritis is a leading cause of physical/motor disability, especially among older adults',
+          'Cerebral palsy, muscular dystrophy, ALS, limb loss/amputation, and repetitive strain injuries are other common motor disabilities tested on the exam',
+          'Motor disabilities frequently pair with AT like switch devices, eye-gaze, alternate keyboards, and voice control'
         ]
       },
       {
@@ -2523,27 +2733,32 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'Market size: Over 1 billion people with disabilities represent significant purchasing power',
-          'Extended market: When including friends and family, the "disability market" reaches over 2.3 billion people globally',
-          'Legal risk: Accessibility lawsuits (especially ADA Title III) are increasing year over year',
-          'SEO benefits: Many accessibility practices (alt text, semantic HTML, captions) also improve search engine optimization',
-          'Innovation: Accessible design drives innovation (curb-cut effect) — many mainstream technologies originated as accessibility solutions (voice control, autocomplete, etc.)',
-          'Aging population: As the population ages, the market for accessible products grows',
-          'Employer brand: Companies known for accessibility attract diverse talent'
+          'Market size: over 1 billion people with disabilities represent significant purchasing power',
+          'Extended market: including friends and family, the "disability market" reaches over 2.3 billion people globally',
+          'Legal risk: accessibility lawsuits (especially ADA Title III web cases in the US) are increasing year over year',
+          'SEO benefits: accessibility practices like alt text, semantic HTML, and captions also improve search engine optimization',
+          'Innovation / curb-cut effect: many mainstream technologies began as accessibility solutions (voice control, autocomplete, sidewalk curb cuts, automatic doors)',
+          'Aging population: as populations age, the market for accessible products grows rapidly',
+          'Employer brand: companies known for accessibility attract and retain diverse talent',
+          'Disability intersects with poverty — people with disabilities are disproportionately affected, making accessibility a social-equity issue as well as an economic one'
         ]
       },
       {
         type: 'callout',
-        text: 'Exam tip: Key numbers to remember: ~16% of the global population has a disability (WHO), 1 in 4 US adults have a disability (CDC), ~2.2 billion people have vision impairments, ~430 million have disabling hearing loss. Cognitive disabilities are the most common type. The business case includes market size, legal risk, SEO, and innovation benefits.'
+        text: 'Exam tip: Memorize the headline numbers: Global ~16% / 1.3B (WHO); EU >25% / ~1 in 4 (Eurostat 2022); US ~26% / 1 in 4 (CDC); Vision 2.2B (WHO); Hearing 430M (WHO); Epilepsy 50M (WHO); Dementia 57M (WHO, 2021). Cognitive disabilities are the most common category. Watch for the category keyword in question stems.'
       }
     ],
-    relatedTopics: ['social-model', 'economic-model', 'ada', 'crpd'],
+    relatedTopics: ['social-model', 'economic-model', 'ada', 'crpd', 'eu-accessibility'],
     examTips: [
-      'WHO: ~16% of global population has a significant disability (~1.3 billion people)',
-      'CDC: 1 in 4 US adults have some type of disability',
+      'Global: ~16% / ~1.3 billion (WHO, 2023 fact sheet)',
+      'EU: more than one-quarter / ~1 in 4 (Eurostat EU-SILC 2022) — distinct from the global 16% figure',
+      'US: ~26% / 1 in 4 adults (CDC)',
+      'Epilepsy ~50M = the neurological condition most commonly cited on exams (WHO)',
+      'Vision ~2.2B and disabling hearing loss ~430M = the headline sensory numbers (WHO)',
+      'Dementia: ~57M in 2021 (WHO) — category overlap between neurological and cognitive',
       'Cognitive disabilities are the most common type globally',
-      'Business case: market size, legal risk, SEO, innovation, aging population',
-      'Disability intersects with poverty — disproportionate economic impact'
+      'Use the category keyword ("sensory," "neurological," "neurodevelopmental," "psychiatric," "motor") in the question stem to narrow options',
+      'Business case: market size, legal risk, SEO, innovation (curb-cut effect), aging population'
     ]
   },
 

--- a/src/data/questions/cpacc-domain1.js
+++ b/src/data/questions/cpacc-domain1.js
@@ -2042,7 +2042,7 @@ export const domain1 = {
       tags: ['statistics', 'neurodevelopmental']
     },
     {
-      id: 1201,
+      id: 901,
       question: "According to the WHO, approximately how many people worldwide have some form of vision impairment (near or distance)?",
       options: [
         "About 430 million",
@@ -2062,7 +2062,7 @@ export const domain1 = {
       tags: ['statistics', 'sensory']
     },
     {
-      id: 1202,
+      id: 902,
       question: "Which statement about global vs. EU disability prevalence is most accurate?",
       options: [
         "The WHO global figure (~16%) and the Eurostat EU figure (~27%) describe the same measurement and should match",
@@ -2082,10 +2082,10 @@ export const domain1 = {
       tags: ['statistics', 'methodology']
     },
     // =============================================
-    // DISABILITY-TO-SOLUTION MATCHING (1203-1210)
+    // DISABILITY-TO-SOLUTION MATCHING (903-910)
     // =============================================
     {
-      id: 1203,
+      id: 903,
       question: "A person who is blind from birth and has never had any usable vision would benefit MOST from which of the following?",
       options: [
         "A screen magnifier with high-contrast color themes",
@@ -2105,7 +2105,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching']
     },
     {
-      id: 1204,
+      id: 904,
       question: "A person with severe motor impairment from ALS who cannot use their hands and has very limited head movement would benefit MOST from which assistive technology?",
       options: [
         "A standard ergonomic keyboard",
@@ -2125,7 +2125,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'motor']
     },
     {
-      id: 1205,
+      id: 905,
       question: "A student with severe dyslexia struggles to decode printed text, even though their reading comprehension is strong when content is read aloud. Which tool is MOST likely to help?",
       options: [
         "A text-to-speech tool that reads on-screen content aloud",
@@ -2145,7 +2145,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'cognitive']
     },
     {
-      id: 1206,
+      id: 906,
       question: "A child with cerebral palsy has significant motor control challenges and cannot reliably use a mouse or standard keyboard, but can reliably press a single large button. Which assistive technology is most appropriate?",
       options: [
         "A refreshable braille display",
@@ -2165,7 +2165,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'motor']
     },
     {
-      id: 1207,
+      id: 907,
       question: "An adult with low vision (not blindness) has usable sight but needs text to be much larger and higher-contrast than standard displays provide. Which tool is MOST appropriate?",
       options: [
         "A screen reader with synthesized speech",
@@ -2185,7 +2185,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'vision']
     },
     {
-      id: 1208,
+      id: 908,
       question: "A person with aphasia (language impairment) following a stroke has difficulty producing spoken words but can recognize pictures and symbols. Which solution would be MOST helpful for everyday communication?",
       options: [
         "A refreshable braille display",
@@ -2205,7 +2205,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'communication']
     },
     {
-      id: 1209,
+      id: 909,
       question: "A person who is Deaf-blind (has both significant hearing and vision loss) is meeting with a group of colleagues. Which communication method is MOST likely to work?",
       options: [
         "A laptop displaying captions on-screen",
@@ -2225,7 +2225,7 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'deaf-blind']
     },
     {
-      id: 1210,
+      id: 910,
       question: "A student with dyscalculia (a specific learning disability affecting number processing) is taking a math assessment. Which accommodation is MOST directly related to their disability?",
       options: [
         "Extended time and access to a calculator or math-support software",
@@ -2245,10 +2245,10 @@ export const domain1 = {
       tags: ['assistive-tech', 'matching', 'cognitive']
     },
     // =============================================
-    // BUILT ENVIRONMENT — FLOOR SURFACES & ROUTES (1211-1214)
+    // BUILT ENVIRONMENT — FLOOR SURFACES & ROUTES (911-914)
     // =============================================
     {
-      id: 1211,
+      id: 911,
       question: "According to ADA Standards §302.1, accessible floor and ground surfaces must have which three characteristics?",
       options: [
         "Smooth, polished, and level",
@@ -2268,7 +2268,7 @@ export const domain1 = {
       tags: ['ada', 'built-environment', 'floor-surfaces']
     },
     {
-      id: 1212,
+      id: 912,
       question: "ADA Standards §302.2 limits carpet pile height in accessible routes to what maximum?",
       options: [
         "1/8 inch",
@@ -2288,7 +2288,7 @@ export const domain1 = {
       tags: ['ada', 'built-environment']
     },
     {
-      id: 1213,
+      id: 913,
       question: "ADA Standards §405.2 sets the maximum running slope for an accessible ramp at:",
       options: [
         "1:8",
@@ -2308,7 +2308,7 @@ export const domain1 = {
       tags: ['ada', 'built-environment', 'ramps']
     },
     {
-      id: 1214,
+      id: 914,
       question: "ADA Standards §403.5 requires that accessible routes have what minimum clear width?",
       options: [
         "24 inches",

--- a/src/data/questions/cpacc-domain1.js
+++ b/src/data/questions/cpacc-domain1.js
@@ -1917,6 +1917,415 @@ export const domain1 = {
       topicLinks: ['inclusive-language'],
       difficulty: 'hard',
       tags: ['inclusive-language', 'etiquette']
+    },
+    // =============================================
+    // EXPANDED DISABILITY STATISTICS (195-202)
+    // =============================================
+    {
+      id: 195,
+      question: "According to the WHO, this neurological condition affects approximately 50 million people worldwide, making it one of the most common neurological diseases globally. Which condition is it?",
+      options: [
+        "Parkinson's disease",
+        "Epilepsy",
+        "Multiple sclerosis",
+        "Huntington's disease"
+      ],
+      correct: 1,
+      explanation: "The WHO reports that around 50 million people worldwide live with epilepsy, and nearly 80% of them live in low- and middle-income countries. Epilepsy is one of the most common neurological diseases globally.",
+      wrongExplanations: {
+        0: "Parkinson's disease is a significant neurological condition but affects far fewer people — roughly 10 million worldwide.",
+        2: "Multiple sclerosis affects approximately 2.8 million people worldwide, far fewer than 50 million.",
+        3: "Huntington's disease is a rare inherited neurological condition affecting only about 3–10 per 100,000 people."
+      },
+      topicLinks: ['disability-demographics'],
+      difficulty: 'medium',
+      tags: ['statistics', 'neurological']
+    },
+    {
+      id: 196,
+      question: "According to Eurostat (EU-SILC 2022 data), approximately what share of the EU population aged 16 and over reports a disability (activity limitation)?",
+      options: [
+        "About 10%",
+        "About 16%",
+        "More than one-quarter (roughly 27%)",
+        "About 40%"
+      ],
+      correct: 2,
+      explanation: "Eurostat's 2022 EU-SILC data shows that more than one-quarter of the EU population aged 16 and over had a disability (activity limitation) — commonly cited as about 27%. This is notably higher than the 16% global figure from the WHO because the EU population is older on average and uses a broader self-reported definition of activity limitation.",
+      wrongExplanations: {
+        0: "10% is too low — no major EU data source reports a figure this low.",
+        1: "16% is the WHO's global prevalence, not the EU-specific rate. Exam questions often use this as a distractor to test whether you can distinguish global from regional statistics.",
+        3: "40% would overstate the EU figure. While some Member States like Latvia (~38.5%) approach this, the EU-wide average is closer to 27%."
+      },
+      topicLinks: ['disability-demographics', 'eu-accessibility'],
+      difficulty: 'hard',
+      tags: ['statistics', 'eu']
+    },
+    {
+      id: 197,
+      question: "The WHO estimates that approximately 1.3 billion people worldwide experience a significant disability. What percentage of the global population does this represent?",
+      options: [
+        "About 5%",
+        "About 16% (roughly 1 in 6)",
+        "About 30%",
+        "About 50%"
+      ],
+      correct: 1,
+      explanation: "Per the WHO's 2023 fact sheet on disability and health, approximately 1.3 billion people — about 16% of the global population, or roughly 1 in 6 — experience a significant disability. This figure is growing because of aging populations and increases in noncommunicable diseases.",
+      wrongExplanations: {
+        0: "5% is far too low — the actual global figure is more than triple this.",
+        2: "30% exceeds even regional figures like the EU (~27%) and would overstate the global rate.",
+        3: "50% is dramatically higher than any credible global disability prevalence estimate."
+      },
+      topicLinks: ['disability-demographics'],
+      difficulty: 'easy',
+      tags: ['statistics', 'global']
+    },
+    {
+      id: 198,
+      question: "According to the WHO, this sensory impairment affects approximately 430 million people worldwide and requires rehabilitation. Which condition does this describe?",
+      options: [
+        "Low vision",
+        "Disabling hearing loss",
+        "Deaf-blindness",
+        "Congenital blindness"
+      ],
+      correct: 1,
+      explanation: "The WHO reports that over 5% of the world's population — about 430 million people, including 34 million children — have disabling hearing loss that requires rehabilitation. By 2050, nearly 2.5 billion people are projected to have some degree of hearing loss, with more than 700 million requiring rehabilitation.",
+      wrongExplanations: {
+        0: "Low vision falls under the broader vision-impairment umbrella. The WHO reports approximately 2.2 billion people have some form of vision impairment, which is a much larger number than 430 million.",
+        2: "Deaf-blindness is a relatively rare combined sensory impairment affecting a much smaller population.",
+        3: "Congenital blindness alone affects far fewer people — the 430 million figure specifically describes disabling hearing loss."
+      },
+      topicLinks: ['disability-demographics'],
+      difficulty: 'medium',
+      tags: ['statistics', 'sensory']
+    },
+    {
+      id: 199,
+      question: "Which category of disability is most commonly cited as the most prevalent globally?",
+      options: [
+        "Motor / physical disabilities",
+        "Sensory disabilities (vision and hearing)",
+        "Cognitive disabilities",
+        "Psychiatric disabilities"
+      ],
+      correct: 2,
+      explanation: "Cognitive disabilities are the most common category of disability globally. This broad category includes learning disabilities, intellectual disabilities, ADHD, memory impairments, and age-related cognitive decline. Because cognitive disabilities cover such a wide range of conditions, they represent the largest overall group.",
+      wrongExplanations: {
+        0: "Motor/physical disabilities are common but not the most prevalent category globally.",
+        1: "Sensory disabilities like vision impairment (2.2B) affect enormous numbers, but the broad cognitive category — which includes many distinct conditions — is still the most commonly cited as most prevalent.",
+        3: "Psychiatric conditions like depression and anxiety are widespread, but they are typically reported as a separate mental health category and are not usually cited as the single most common disability type."
+      },
+      topicLinks: ['disability-demographics', 'cognitive-disabilities'],
+      difficulty: 'medium',
+      tags: ['statistics', 'cognitive']
+    },
+    {
+      id: 200,
+      question: "The WHO reports that this neurodevelopmental condition affects approximately 1 in 127 people globally based on 2021 estimates. Which condition is it?",
+      options: [
+        "Down syndrome",
+        "ADHD",
+        "Autism spectrum disorder",
+        "Dyslexia"
+      ],
+      correct: 2,
+      explanation: "The WHO estimates that in 2021 about 1 in 127 persons had autism spectrum disorder, although reported prevalence varies substantially across studies and some national sources (like the US CDC) cite higher rates for children specifically.",
+      wrongExplanations: {
+        0: "Down syndrome is a genetic condition occurring in approximately 1 in 700 births, which is much rarer than autism.",
+        1: "ADHD is far more prevalent than 1 in 127 — it affects roughly 5–10% of children, or about 1 in 10 to 1 in 20.",
+        3: "Dyslexia affects an estimated 5–10% of the population — much more prevalent than 1 in 127."
+      },
+      topicLinks: ['disability-demographics', 'cognitive-disabilities'],
+      difficulty: 'hard',
+      tags: ['statistics', 'neurodevelopmental']
+    },
+    {
+      id: 1201,
+      question: "According to the WHO, approximately how many people worldwide have some form of vision impairment (near or distance)?",
+      options: [
+        "About 430 million",
+        "About 1 billion",
+        "About 2.2 billion",
+        "About 4 billion"
+      ],
+      correct: 2,
+      explanation: "The WHO reports that globally, at least 2.2 billion people have a near or distance vision impairment. For at least 1 billion of these people, the vision impairment could have been prevented or has yet to be addressed. This is the headline sensory statistic often cited on the exam.",
+      wrongExplanations: {
+        0: "430 million is the WHO's figure for disabling hearing loss, not vision impairment. Watch for this as a distractor swap.",
+        1: "1 billion represents the subset of the 2.2 billion whose vision impairment could have been prevented or is unaddressed — not the total.",
+        3: "4 billion would be about half the world's population, which exceeds all published vision impairment estimates."
+      },
+      topicLinks: ['disability-demographics'],
+      difficulty: 'medium',
+      tags: ['statistics', 'sensory']
+    },
+    {
+      id: 1202,
+      question: "Which statement about global vs. EU disability prevalence is most accurate?",
+      options: [
+        "The WHO global figure (~16%) and the Eurostat EU figure (~27%) describe the same measurement and should match",
+        "The EU figure is higher partly because the EU population is older on average and uses a broader self-reported activity-limitation definition",
+        "The EU figure is lower than the global figure because European healthcare reduces disability",
+        "The WHO and Eurostat use identical methodologies, so any difference is a reporting error"
+      ],
+      correct: 1,
+      explanation: "Global and regional disability figures differ because of methodology and demographics. The WHO's ~16% global figure uses a 'significant disability' threshold across all ages and income levels, while Eurostat's ~27% figure is for adults aged 16+ in the EU using a self-reported activity-limitation measure from the EU-SILC survey. The EU population is also older on average, which increases measured disability.",
+      wrongExplanations: {
+        0: "The two figures use different age ranges, definitions, and survey methodologies — they are not directly comparable.",
+        2: "EU disability rates are higher than the global average, not lower. Better healthcare access leads to longer lifespans, which in turn increases the measured prevalence of age-related disability.",
+        3: "The methodologies differ significantly; differences are a feature of the definitions, not errors."
+      },
+      topicLinks: ['disability-demographics', 'eu-accessibility'],
+      difficulty: 'hard',
+      tags: ['statistics', 'methodology']
+    },
+    // =============================================
+    // DISABILITY-TO-SOLUTION MATCHING (1203-1210)
+    // =============================================
+    {
+      id: 1203,
+      question: "A person who is blind from birth and has never had any usable vision would benefit MOST from which of the following?",
+      options: [
+        "A screen magnifier with high-contrast color themes",
+        "A screen reader combined with a refreshable braille display",
+        "Closed captions on all video content",
+        "Voice control software for hands-free operation"
+      ],
+      correct: 1,
+      explanation: "A person who is blind relies on non-visual access to information. A screen reader converts on-screen content to synthesized speech, and a refreshable braille display renders it as tactile braille — together they provide complete non-visual access to digital content.",
+      wrongExplanations: {
+        0: "Screen magnifiers benefit people with low vision who have some usable sight. They are not useful to someone who is blind.",
+        2: "Captions benefit people who are Deaf or hard of hearing, not blind users. Audio description (not captions) is what benefits blind users consuming video.",
+        3: "Voice control primarily benefits people with motor disabilities. A blind person can typically use a keyboard with a screen reader without needing voice input."
+      },
+      topicLinks: ['screen-readers', 'visual-disabilities'],
+      difficulty: 'easy',
+      tags: ['assistive-tech', 'matching']
+    },
+    {
+      id: 1204,
+      question: "A person with severe motor impairment from ALS who cannot use their hands and has very limited head movement would benefit MOST from which assistive technology?",
+      options: [
+        "A standard ergonomic keyboard",
+        "Screen magnification software",
+        "An eye-gaze (eye tracking) communication and computer access system",
+        "A refreshable braille display"
+      ],
+      correct: 2,
+      explanation: "When someone has extremely limited motor control — unable to use their hands and with very limited head movement — eye-gaze technology allows them to control a computer and communicate using only their eye movements. Users select letters, words, or commands by looking at targets on the screen.",
+      wrongExplanations: {
+        0: "An ergonomic keyboard still requires hand use, which this individual does not have.",
+        1: "Screen magnification addresses vision, not motor access.",
+        3: "Refreshable braille displays are for people who are blind and read braille, not for people with motor disabilities."
+      },
+      topicLinks: ['mobility-disabilities'],
+      difficulty: 'medium',
+      tags: ['assistive-tech', 'matching', 'motor']
+    },
+    {
+      id: 1205,
+      question: "A student with severe dyslexia struggles to decode printed text, even though their reading comprehension is strong when content is read aloud. Which tool is MOST likely to help?",
+      options: [
+        "A text-to-speech tool that reads on-screen content aloud",
+        "A screen magnifier",
+        "Switch access controls",
+        "Closed captions"
+      ],
+      correct: 0,
+      explanation: "Text-to-speech (TTS) tools read digital text aloud, bypassing the decoding barrier that dyslexia creates. Because the student's comprehension is strong when content is heard, TTS lets them access the same material as their peers without the decoding bottleneck.",
+      wrongExplanations: {
+        1: "Magnification addresses vision size, not decoding.",
+        2: "Switch access is for people with motor disabilities who cannot use a standard input device.",
+        3: "Captions convert speech to text — the opposite of what a dyslexic reader needs."
+      },
+      topicLinks: ['cognitive-disabilities'],
+      difficulty: 'easy',
+      tags: ['assistive-tech', 'matching', 'cognitive']
+    },
+    {
+      id: 1206,
+      question: "A child with cerebral palsy has significant motor control challenges and cannot reliably use a mouse or standard keyboard, but can reliably press a single large button. Which assistive technology is most appropriate?",
+      options: [
+        "A refreshable braille display",
+        "A switch-access system with scanning",
+        "A hearing loop",
+        "A screen reader"
+      ],
+      correct: 1,
+      explanation: "Switch access paired with on-screen scanning is designed exactly for this scenario. The computer highlights options sequentially, and the user presses a single switch (often a large button) when the desired option is highlighted. This provides full computer access with minimal motor demand.",
+      wrongExplanations: {
+        0: "Braille displays are for blind users, not motor users.",
+        2: "Hearing loops are assistive listening devices for people with hearing aids.",
+        3: "Screen readers are for people with visual impairments, not motor disabilities."
+      },
+      topicLinks: ['mobility-disabilities'],
+      difficulty: 'medium',
+      tags: ['assistive-tech', 'matching', 'motor']
+    },
+    {
+      id: 1207,
+      question: "An adult with low vision (not blindness) has usable sight but needs text to be much larger and higher-contrast than standard displays provide. Which tool is MOST appropriate?",
+      options: [
+        "A screen reader with synthesized speech",
+        "An eye-gaze communication system",
+        "A screen magnifier with customizable color themes",
+        "A single-switch scanning system"
+      ],
+      correct: 2,
+      explanation: "People with low vision typically retain usable sight and benefit most from visual enhancements — magnification, customizable high-contrast color schemes, and cursor enhancements. Screen magnifiers let the user zoom the entire display and adjust colors to their preference.",
+      wrongExplanations: {
+        0: "Screen readers are primarily for people who are blind or have vision so limited that visual access is not practical. Someone with usable low vision typically prefers to continue reading visually with magnification.",
+        1: "Eye-gaze is a motor-access technology.",
+        3: "Switch scanning is a motor-access technology."
+      },
+      topicLinks: ['visual-disabilities'],
+      difficulty: 'easy',
+      tags: ['assistive-tech', 'matching', 'vision']
+    },
+    {
+      id: 1208,
+      question: "A person with aphasia (language impairment) following a stroke has difficulty producing spoken words but can recognize pictures and symbols. Which solution would be MOST helpful for everyday communication?",
+      options: [
+        "A refreshable braille display",
+        "A picture-based augmentative and alternative communication (AAC) app or device",
+        "Closed captioning",
+        "A screen reader"
+      ],
+      correct: 1,
+      explanation: "Picture-based AAC systems let people with aphasia or other expressive communication disabilities communicate by selecting symbols or images. Many users can recognize and select pictures even when they cannot produce or recall spoken words, and modern AAC apps can generate spoken output from the selections.",
+      wrongExplanations: {
+        0: "Braille displays are for people who are blind and read braille.",
+        2: "Captions convert speech to written text — this helps people who have trouble hearing speech, not people who have trouble producing it.",
+        3: "Screen readers convert digital text to speech — they are output tools for visual impairment, not input tools for communication difficulties."
+      },
+      topicLinks: ['speech-disabilities', 'cognitive-disabilities'],
+      difficulty: 'medium',
+      tags: ['assistive-tech', 'matching', 'communication']
+    },
+    {
+      id: 1209,
+      question: "A person who is Deaf-blind (has both significant hearing and vision loss) is meeting with a group of colleagues. Which communication method is MOST likely to work?",
+      options: [
+        "A laptop displaying captions on-screen",
+        "A sign language interpreter standing at the front of the room",
+        "A Support Service Provider (SSP) or tactile interpreter using methods such as Protactile or tactile sign language",
+        "An assistive listening device broadcast to the room"
+      ],
+      correct: 2,
+      explanation: "People who are Deaf-blind typically rely on tactile communication methods like tactile sign language, Protactile, or print-on-palm, facilitated by a Support Service Provider (SSP) or tactile interpreter. Visual captions and visual sign language both require sight, which rules them out for someone who is also blind.",
+      wrongExplanations: {
+        0: "Captions require usable vision.",
+        1: "Visual sign language requires usable vision.",
+        3: "Assistive listening devices require usable hearing."
+      },
+      topicLinks: ['auditory-disabilities', 'visual-disabilities', 'deaf-blindness'],
+      difficulty: 'hard',
+      tags: ['assistive-tech', 'matching', 'deaf-blind']
+    },
+    {
+      id: 1210,
+      question: "A student with dyscalculia (a specific learning disability affecting number processing) is taking a math assessment. Which accommodation is MOST directly related to their disability?",
+      options: [
+        "Extended time and access to a calculator or math-support software",
+        "A sign language interpreter",
+        "A screen reader",
+        "A wheelchair-accessible desk"
+      ],
+      correct: 0,
+      explanation: "Dyscalculia specifically impairs number sense and numerical processing. The most directly relevant accommodations are extended time (to compensate for slower computation) and access to a calculator or dedicated math-support software, which reduces the cognitive load of basic numerical operations so the student can demonstrate their conceptual understanding.",
+      wrongExplanations: {
+        1: "A sign language interpreter addresses hearing access, not number processing.",
+        2: "A screen reader addresses visual access, not number processing.",
+        3: "A wheelchair-accessible desk addresses mobility, not number processing."
+      },
+      topicLinks: ['cognitive-disabilities'],
+      difficulty: 'medium',
+      tags: ['assistive-tech', 'matching', 'cognitive']
+    },
+    // =============================================
+    // BUILT ENVIRONMENT — FLOOR SURFACES & ROUTES (1211-1214)
+    // =============================================
+    {
+      id: 1211,
+      question: "According to ADA Standards §302.1, accessible floor and ground surfaces must have which three characteristics?",
+      options: [
+        "Smooth, polished, and level",
+        "Stable, firm, and slip-resistant",
+        "Textured, padded, and cushioned",
+        "Flexible, pliable, and shock-absorbing"
+      ],
+      correct: 1,
+      explanation: "ADA Standards §302.1 requires that accessible floor and ground surfaces be stable (not shifting under load), firm (not compressing significantly), and slip-resistant (providing adequate friction for canes, crutches, walkers, and wheelchair wheels). This three-word phrase is a classic exam answer.",
+      wrongExplanations: {
+        0: "Polished surfaces can be dangerously slippery — the opposite of slip-resistant.",
+        2: "Padded or cushioned surfaces compress under wheelchair wheels, making them unstable and difficult to traverse. The requirement is firm, not soft.",
+        3: "Pliable and shock-absorbing surfaces are unstable for wheelchair users and would violate the firm and stable requirements."
+      },
+      topicLinks: ['built-environment'],
+      difficulty: 'medium',
+      tags: ['ada', 'built-environment', 'floor-surfaces']
+    },
+    {
+      id: 1212,
+      question: "ADA Standards §302.2 limits carpet pile height in accessible routes to what maximum?",
+      options: [
+        "1/8 inch",
+        "1/2 inch",
+        "1 inch",
+        "2 inches"
+      ],
+      correct: 1,
+      explanation: "ADA §302.2 limits carpet pile height to 1/2 inch maximum, measured to the backing, cushion, or pad. Carpet must be securely attached with a firm backing, and exposed edges must be fastened and trimmed. Deeper pile creates excessive rolling resistance for wheelchair users and is a tripping hazard for people using mobility aids.",
+      wrongExplanations: {
+        0: "1/8 inch would be stricter than the actual ADA requirement of 1/2 inch.",
+        2: "1 inch is double the allowed maximum and would impede wheelchair travel.",
+        3: "2 inches of pile would be impassable for most wheelchair users."
+      },
+      topicLinks: ['built-environment'],
+      difficulty: 'hard',
+      tags: ['ada', 'built-environment']
+    },
+    {
+      id: 1213,
+      question: "ADA Standards §405.2 sets the maximum running slope for an accessible ramp at:",
+      options: [
+        "1:8",
+        "1:10",
+        "1:12",
+        "1:20"
+      ],
+      correct: 2,
+      explanation: "ADA §405.2 limits the running slope of accessible ramps to 1:12 — one inch of vertical rise for every twelve inches of horizontal run. Each single ramp run is also limited to a maximum rise of 30 inches before a landing is required. In alterations where space is limited, slightly steeper slopes (1:10 for ≤6\" rise, 1:8 for ≤3\" rise) are permitted as exceptions.",
+      wrongExplanations: {
+        0: "1:8 is only permitted as a space-limited exception for very small rises (≤3 inches), not as the standard maximum.",
+        1: "1:10 is only permitted as a space-limited exception for ≤6 inches of rise.",
+        3: "1:20 is the cut-off slope below which a walkway is not even considered a ramp — it is gentler than the ramp maximum."
+      },
+      topicLinks: ['built-environment'],
+      difficulty: 'medium',
+      tags: ['ada', 'built-environment', 'ramps']
+    },
+    {
+      id: 1214,
+      question: "ADA Standards §403.5 requires that accessible routes have what minimum clear width?",
+      options: [
+        "24 inches",
+        "32 inches",
+        "36 inches",
+        "48 inches"
+      ],
+      correct: 2,
+      explanation: "ADA §403.5 requires accessible routes to have a minimum clear width of 36 inches. This may be reduced to 32 inches minimum at a point (for example, at a doorway) for a maximum length of 24 inches. The 36-inch minimum ensures most wheelchairs, walkers, and mobility scooters can pass comfortably.",
+      wrongExplanations: {
+        0: "24 inches is too narrow for most wheelchairs — it is not a valid minimum.",
+        1: "32 inches is the allowable point reduction at a doorway, not the general minimum width for a route.",
+        3: "48 inches exceeds the ADA minimum — wider is better, but 36 inches is the required minimum."
+      },
+      topicLinks: ['built-environment'],
+      difficulty: 'medium',
+      tags: ['ada', 'built-environment', 'routes']
     }
   ]
 };

--- a/src/data/questions/cpacc-domain2.js
+++ b/src/data/questions/cpacc-domain2.js
@@ -1726,6 +1726,211 @@ export const domain2 = {
       topicLinks: ['user-centered-design', 'universal-design-principles', 'universal-design-learning'],
       difficulty: 'hard',
       tags: ['user-centered-design', 'universal-design', 'udl', 'distinction']
+    },
+
+    // ============================================================
+    // UDL DEEP-DIVE (291-300)
+    // Targets gap: UDL sub-principles, especially Action & Expression
+    // ============================================================
+    {
+      id: 291,
+      question: "Universal Design for Learning (UDL) is built on three principles aligned with three brain networks. Which brain network corresponds to the 'Engagement' principle — the WHY of learning?",
+      options: [
+        "Affective network",
+        "Recognition network",
+        "Strategic network",
+        "Executive network"
+      ],
+      correct: 0,
+      explanation: "The Engagement principle — the WHY of learning — aligns with the affective network. The affective network governs motivation, interest, and emotional response. UDL's Engagement guidelines offer multiple means of recruiting interest, sustaining effort and persistence, and supporting self-regulation.",
+      wrongExplanations: {
+        1: "The recognition network corresponds to the Representation principle (the WHAT of learning) — how learners perceive and comprehend information.",
+        2: "The strategic network corresponds to the Action & Expression principle (the HOW of learning) — how learners plan and perform tasks.",
+        3: "'Executive network' is not one of the three UDL brain networks. Executive function is a checkpoint under Action & Expression, but the network itself is called strategic."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'easy',
+      tags: ['udl', 'engagement', 'brain-networks']
+    },
+    {
+      id: 292,
+      question: "Which brain network does the 'Action & Expression' UDL principle align with?",
+      options: [
+        "Strategic network",
+        "Affective network",
+        "Recognition network",
+        "Sensory network"
+      ],
+      correct: 0,
+      explanation: "Action & Expression — the HOW of learning — aligns with the strategic network. The strategic network, located primarily in the frontal lobes, handles planning, executing, and monitoring actions. UDL's Action & Expression guidelines provide multiple means for physical action, expression & communication, and executive functions (goal-setting, planning, self-monitoring).",
+      wrongExplanations: {
+        1: "The affective network corresponds to Engagement (WHY), governing motivation and emotional response.",
+        2: "The recognition network corresponds to Representation (WHAT), governing perception and comprehension of information.",
+        3: "'Sensory network' is not one of the three UDL brain networks."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'easy',
+      tags: ['udl', 'action-expression', 'strategic-network']
+    },
+    {
+      id: 293,
+      question: "A teacher allows students to choose between writing an essay, recording a podcast, or creating a video presentation to demonstrate their understanding of a historical event. Which UDL principle AND sub-principle (checkpoint area) does this practice MOST directly support?",
+      options: [
+        "Action & Expression — provide options for expression and communication",
+        "Engagement — provide options for recruiting interest",
+        "Representation — provide options for comprehension",
+        "Action & Expression — provide options for physical action"
+      ],
+      correct: 0,
+      explanation: "Offering multiple formats for students to demonstrate learning (essay, podcast, video) directly supports the 'expression and communication' checkpoint under Action & Expression. This sub-principle recognizes that learners differ in how they can best express what they know, and that no single medium is ideal for every learner.",
+      wrongExplanations: {
+        1: "While choice can boost engagement, the primary UDL mapping here is about HOW students express their learning — that belongs under Action & Expression, not Engagement's 'recruiting interest' checkpoint.",
+        2: "Representation is about how information is presented TO learners (input). This example is about how learners demonstrate their understanding (output), which is Action & Expression.",
+        3: "'Physical action' specifically addresses tools, assistive technologies, and navigation (e.g., alternatives to keyboard/mouse). Format choice for assignments is about expression and communication, not physical access."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'medium',
+      tags: ['udl', 'action-expression', 'expression-communication']
+    },
+    {
+      id: 294,
+      question: "A science textbook provides definitions for technical vocabulary, background knowledge summaries, and graphic organizers that show how concepts relate. Which UDL principle and checkpoint do these supports MOST directly address?",
+      options: [
+        "Representation — provide options for language, mathematical expressions, and symbols; and for comprehension",
+        "Engagement — provide options for sustaining effort and persistence",
+        "Action & Expression — provide options for executive functions",
+        "Representation — provide options for perception"
+      ],
+      correct: 0,
+      explanation: "Vocabulary support, background knowledge, and graphic organizers directly address two Representation checkpoints: 'language, mathematical expressions, and symbols' (clarifying vocabulary and syntax) and 'comprehension' (activating prior knowledge, highlighting patterns and relationships). These supports help learners process and make sense of information.",
+      wrongExplanations: {
+        1: "Sustaining effort and persistence is an Engagement checkpoint addressing motivation — not the cognitive supports described here.",
+        2: "Executive functions (goal-setting, planning, self-monitoring) are an Action & Expression checkpoint — these help learners manage their own learning, not process content.",
+        3: "'Perception' checkpoints address how information is displayed (customizable text, alternatives for audio/visual). Vocabulary and comprehension supports go beyond perception into meaning-making."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'medium',
+      tags: ['udl', 'representation', 'comprehension']
+    },
+    {
+      id: 295,
+      question: "A teacher uses a rubric, a daily planner, and explicit goal-setting prompts to help students manage long-term projects. Which UDL checkpoint area is this supporting?",
+      options: [
+        "Action & Expression — executive functions",
+        "Engagement — self-regulation",
+        "Action & Expression — physical action",
+        "Representation — comprehension"
+      ],
+      correct: 0,
+      explanation: "Rubrics, planners, and goal-setting prompts support 'executive functions,' a checkpoint under Action & Expression. Executive functions include setting appropriate goals, planning and strategy development, managing information and resources, and monitoring progress. These supports scaffold the strategic network that learners use to manage their own work.",
+      wrongExplanations: {
+        1: "Self-regulation (under Engagement) is about managing emotions, motivation, and coping with frustration — not the cognitive planning and monitoring tools described here.",
+        2: "Physical action addresses tools for interacting with materials (assistive tech, alternative input methods). Planning tools are about cognition, not physical access.",
+        3: "Comprehension is about understanding content. Project management tools help with executing work, not understanding subject matter."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'medium',
+      tags: ['udl', 'action-expression', 'executive-functions']
+    },
+    {
+      id: 296,
+      question: "A learner with a motor impairment uses a switch interface and an alternative keyboard to navigate digital learning materials. Which Action & Expression checkpoint does the inclusion of these assistive technology options support?",
+      options: [
+        "Provide options for physical action",
+        "Provide options for expression and communication",
+        "Provide options for executive functions",
+        "Provide options for perception"
+      ],
+      correct: 0,
+      explanation: "'Physical action' is the Action & Expression checkpoint that addresses varying the methods for response, navigation, and interaction — including assistive technologies, alternative keyboards, switches, and voice-activated controls. This checkpoint ensures that the physical act of engaging with materials does not become a barrier.",
+      wrongExplanations: {
+        1: "Expression and communication is about the MEDIA learners use to demonstrate learning (text, speech, video, etc.), not the physical input methods.",
+        2: "Executive functions is about planning, goal-setting, and self-monitoring — a cognitive checkpoint, not a physical one.",
+        3: "Perception is under Representation, not Action & Expression."
+      },
+      topicLinks: ['universal-design-learning', 'assistive-technology'],
+      difficulty: 'medium',
+      tags: ['udl', 'action-expression', 'physical-action']
+    },
+    {
+      id: 297,
+      question: "A middle school teacher offers students choice in assignment topics, allows them to set personal learning goals, and connects lessons to students' cultural backgrounds and interests. Which UDL principle does this MOST directly support?",
+      options: [
+        "Engagement — recruiting interest",
+        "Representation — comprehension",
+        "Action & Expression — expression and communication",
+        "Engagement — self-regulation"
+      ],
+      correct: 0,
+      explanation: "Offering choice, personal relevance, and cultural connection directly supports the 'recruiting interest' checkpoint under Engagement. This checkpoint emphasizes optimizing individual choice and autonomy, optimizing relevance, value, and authenticity, and minimizing threats and distractions — all to spark learners' motivation to engage.",
+      wrongExplanations: {
+        1: "Comprehension (Representation) addresses how learners process information, not how their interest is sparked.",
+        2: "Expression and communication is about how learners demonstrate learning, not what draws them in.",
+        3: "Self-regulation (also Engagement) is about managing emotions, developing coping skills, and self-assessment — not the initial recruitment of interest described here."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'medium',
+      tags: ['udl', 'engagement', 'recruiting-interest']
+    },
+    {
+      id: 298,
+      question: "A video lesson includes captions, a transcript, audio description of visual elements, and allows learners to adjust playback speed and text size. Which UDL checkpoint area do these features MOST directly serve?",
+      options: [
+        "Representation — perception",
+        "Engagement — sustaining effort and persistence",
+        "Action & Expression — physical action",
+        "Representation — comprehension"
+      ],
+      correct: 0,
+      explanation: "Captions, transcripts, audio description, and customizable display are all 'perception' checkpoints under Representation. The perception checkpoint covers offering ways of customizing the display of information, offering alternatives for auditory information, and offering alternatives for visual information — ensuring all learners can perceive the content regardless of sensory ability.",
+      wrongExplanations: {
+        1: "Sustaining effort and persistence addresses motivation over time — fostering collaboration, mastery-oriented feedback, etc. — not sensory access.",
+        2: "Physical action addresses input methods and navigation tools, not how information is perceived.",
+        3: "Comprehension addresses making meaning from information (background knowledge, vocabulary, patterns). Perception comes first — it addresses whether the information can be received at all."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'medium',
+      tags: ['udl', 'representation', 'perception']
+    },
+    {
+      id: 299,
+      question: "A teacher argues that adding UDL supports — like captions, choice of assignment format, and goal-setting scaffolds — is only necessary for students with documented disabilities and amounts to 'lowering standards' for other students. What is the MOST accurate UDL-based response?",
+      options: [
+        "UDL is designed for all learners from the start — variability is the norm, not the exception — and providing multiple means of engagement, representation, and action & expression raises rather than lowers expectations by giving every learner pathways to rigorous content",
+        "UDL is primarily a disability accommodation framework and the teacher is correct that it should be limited to students with IEPs",
+        "UDL replaces curriculum standards with individualized goals for each student",
+        "UDL lowers standards but increases graduation rates, which is a worthwhile tradeoff"
+      ],
+      correct: 0,
+      explanation: "UDL's foundational premise is that learner variability is predictable and universal — there is no 'average learner.' By designing flexible curricula from the outset with multiple means of engagement, representation, and action & expression, UDL removes barriers for everyone while maintaining (and often raising) expectations. The goal is to become 'expert learners' who are purposeful, resourceful, and strategic — not to lower rigor.",
+      wrongExplanations: {
+        1: "UDL was developed by CAST to benefit ALL learners, not just students with disabilities. Its framework is rooted in neuroscience research on learner variability across the entire population.",
+        2: "UDL does not replace curriculum standards. It provides flexible pathways TO those standards, keeping learning goals constant while varying the means.",
+        3: "UDL does not lower standards. Research shows UDL implementations maintain or raise expectations while making them accessible to more learners."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'hard',
+      tags: ['udl', 'philosophy', 'expert-learners']
+    },
+    {
+      id: 300,
+      question: "A curriculum designer is reviewing a unit and notices that students can only demonstrate their learning through a written test, and that struggling writers — including students with dysgraphia, English language learners, and students with expressive language disorders — consistently underperform despite understanding the content. Using the UDL framework, what is the MOST appropriate redesign strategy?",
+      options: [
+        "Add alternative formats for demonstrating learning (oral exam, project, multimedia presentation) under the Action & Expression principle, so the assessment measures content knowledge rather than writing ability",
+        "Keep the written test but add extra time as the only accommodation, since writing is an essential skill",
+        "Replace the assessment with a purely verbal exam for all students",
+        "Exempt struggling writers from the assessment entirely"
+      ],
+      correct: 0,
+      explanation: "The written-only test creates a construct-irrelevant barrier — it measures writing ability in addition to (or instead of) the content the unit is meant to assess. Under Action & Expression, offering multiple means of expression and communication lets every learner demonstrate what they know in the modality that best reveals their understanding. This preserves rigor while removing an artificial barrier. Adding extra time (option 2) only partially addresses the barrier. Replacing with verbal-only (option 3) just shifts the barrier. Exempting students (option 4) denies them the opportunity to demonstrate learning.",
+      wrongExplanations: {
+        1: "Extra time alone doesn't remove the fundamental barrier: the assessment still requires writing as the sole expression mode. Unless writing itself is the construct being measured, the test continues to measure the wrong thing for these learners.",
+        2: "A verbal-only exam simply shifts the barrier to students who struggle with verbal expression. UDL calls for multiple means, not a single replacement mode.",
+        3: "Exempting students denies them the chance to show what they know. UDL aims to include all learners, not remove them from assessment."
+      },
+      topicLinks: ['universal-design-learning'],
+      difficulty: 'hard',
+      tags: ['udl', 'action-expression', 'assessment-design']
     }
   ]
 };

--- a/src/data/questions/cpacc-domain3.js
+++ b/src/data/questions/cpacc-domain3.js
@@ -1419,6 +1419,316 @@ export const domain3 = {
       topicLinks: ['w3c-wai'],
       difficulty: 'easy',
       tags: ['standards']
+    },
+
+    // ============================================================
+    // EUROPEAN REGULATIONS DEEP-DIVE (371-378)
+    // Targets gap: EN 17161 Design for All, eIDAS, WAD vs EAA
+    // ============================================================
+    {
+      id: 371,
+      question: "Which European standard defines a 'Design for All' methodology for organizations to follow when developing products, goods, and services so that the widest possible range of users can access and use them?",
+      options: [
+        "EN 17161:2019",
+        "EN 301 549",
+        "EN ISO 9241-171",
+        "EN 15838"
+      ],
+      correct: 0,
+      explanation: "EN 17161:2019 — 'Design for All — Accessibility following a Design for All approach in products, goods and services — Extending the range of users' — is a CEN (European Committee for Standardization) standard that provides a process-oriented management standard. It guides organizations in embedding Design for All into their development processes so that outputs are accessible to the widest possible range of users. It complements technical standards like EN 301 549.",
+      wrongExplanations: {
+        1: "EN 301 549 is the European harmonized standard for ICT accessibility requirements. It specifies technical requirements for ICT products (websites, hardware, software) but is not itself a Design for All methodology — it defines WHAT to meet, while EN 17161 defines HOW to develop inclusively.",
+        2: "EN ISO 9241-171 provides guidance on software accessibility but is not the Design for All methodology standard.",
+        3: "EN 15838 relates to customer contact centres, not accessibility or Design for All."
+      },
+      topicLinks: ['eu-accessibility', 'en-301-549'],
+      difficulty: 'medium',
+      tags: ['european-regulations', 'en-17161', 'design-for-all']
+    },
+    {
+      id: 372,
+      question: "EN 17161:2019 and EN 301 549 are both European accessibility standards, but they serve different purposes. Which statement BEST distinguishes them?",
+      options: [
+        "EN 17161 is a process/management standard describing HOW organizations embed Design for All; EN 301 549 is a technical standard specifying WHAT ICT accessibility requirements must be met",
+        "EN 17161 is for public sector; EN 301 549 is for private sector",
+        "EN 17161 replaced EN 301 549 in 2019",
+        "EN 17161 is a voluntary guideline; EN 301 549 is only informative"
+      ],
+      correct: 0,
+      explanation: "EN 17161 is a MANAGEMENT/PROCESS standard — it describes how an organization should approach design so that Design for All is integrated throughout the product lifecycle. EN 301 549 is a TECHNICAL standard — it specifies the concrete accessibility requirements that ICT (websites, software, hardware) must meet, and is the harmonized standard used for Web Accessibility Directive and European Accessibility Act conformance. They are complementary, not overlapping.",
+      wrongExplanations: {
+        1: "Neither standard is scoped to public or private sector in that way. EN 301 549 is used for BOTH public sector (via WAD) and increasingly private sector (via EAA) conformance.",
+        2: "EN 17161 did not replace EN 301 549. They are distinct standards with different scopes that coexist.",
+        3: "Both are formal CEN/CENELEC/ETSI standards; EN 301 549 in particular is a harmonized standard cited in EU legislation, not merely informative."
+      },
+      topicLinks: ['eu-accessibility', 'en-301-549'],
+      difficulty: 'hard',
+      tags: ['european-regulations', 'en-17161', 'en-301-549']
+    },
+    {
+      id: 373,
+      question: "Which EU regulation governs electronic identification, authentication, and trust services for electronic transactions in the internal market, and includes requirements that electronic identification means be accessible to persons with disabilities when used for cross-border public services?",
+      options: [
+        "eIDAS — Regulation (EU) No 910/2014",
+        "GDPR — Regulation (EU) 2016/679",
+        "Digital Services Act — Regulation (EU) 2022/2065",
+        "ePrivacy Directive 2002/58/EC"
+      ],
+      correct: 0,
+      explanation: "eIDAS — the electronic IDentification, Authentication and trust Services regulation, Regulation (EU) No 910/2014 — establishes an EU-wide framework for electronic identification and trust services (electronic signatures, seals, time stamps, registered delivery, website authentication). It includes provisions that electronic identification schemes used for cross-border public services must be accessible to persons with disabilities where possible.",
+      wrongExplanations: {
+        1: "GDPR governs data protection and privacy, not electronic identification and trust services.",
+        2: "The Digital Services Act regulates online intermediaries and platforms (content moderation, transparency), not electronic identity.",
+        3: "The ePrivacy Directive addresses confidentiality of electronic communications, not electronic identification."
+      },
+      topicLinks: ['eu-accessibility'],
+      difficulty: 'medium',
+      tags: ['european-regulations', 'eidas']
+    },
+    {
+      id: 374,
+      question: "A citizen in one EU member state wants to access an online public service in another EU member state. Which regulation ensures that their national electronic ID can be recognized across borders, and contains accessibility provisions for persons with disabilities?",
+      options: [
+        "eIDAS (Regulation 910/2014)",
+        "Web Accessibility Directive (EU 2016/2102)",
+        "European Accessibility Act (Directive 2019/882)",
+        "EN 301 549"
+      ],
+      correct: 0,
+      explanation: "eIDAS (Regulation 910/2014) enables mutual recognition of notified electronic identification schemes across EU member states for access to cross-border public services. It includes provisions that, where possible, these electronic identification means should be accessible to persons with disabilities. While WAD and EAA cover the accessibility of the web content and digital products themselves, eIDAS specifically addresses the cross-border e-ID layer.",
+      wrongExplanations: {
+        1: "The Web Accessibility Directive requires public sector websites and mobile apps to be accessible but does not govern cross-border electronic identification.",
+        2: "The European Accessibility Act targets accessibility of certain products and services in the private sector, not cross-border e-ID.",
+        3: "EN 301 549 is a technical standard specifying accessibility requirements — not a regulation on electronic identification."
+      },
+      topicLinks: ['eu-accessibility'],
+      difficulty: 'hard',
+      tags: ['european-regulations', 'eidas', 'cross-border']
+    },
+    {
+      id: 375,
+      question: "The EU Web Accessibility Directive (WAD) and the European Accessibility Act (EAA) have different scopes. Which statement correctly distinguishes them?",
+      options: [
+        "WAD (2016/2102) requires public sector websites and mobile apps to be accessible; EAA (Directive 2019/882) requires certain private sector products and services (e.g., e-commerce, banking, e-books, ticketing) to be accessible",
+        "WAD covers private sector, EAA covers public sector",
+        "WAD and EAA both cover only physical built environments",
+        "WAD replaced the EAA in 2019"
+      ],
+      correct: 0,
+      explanation: "The Web Accessibility Directive (Directive (EU) 2016/2102) requires public sector bodies' websites and mobile applications to be accessible and to publish accessibility statements. The European Accessibility Act (Directive (EU) 2019/882) extends accessibility requirements to key private sector products and services — including computers, smartphones, e-commerce, banking services, e-books, consumer banking terminals, and passenger transport information. Most EAA provisions became applicable on 28 June 2025. Both reference EN 301 549 for technical conformance.",
+      wrongExplanations: {
+        1: "This reverses the scopes. WAD covers the public sector; EAA covers the private sector.",
+        2: "Neither WAD nor EAA covers only physical environments — both focus primarily on digital products and services.",
+        3: "WAD (2016) preceded EAA (2019). EAA extended accessibility requirements into new sectors; it was not replaced."
+      },
+      topicLinks: ['eu-accessibility'],
+      difficulty: 'medium',
+      tags: ['european-regulations', 'wad', 'eaa']
+    },
+    {
+      id: 376,
+      question: "Under the EU Web Accessibility Directive, public sector bodies must do which of the following in addition to making their websites and mobile apps accessible?",
+      options: [
+        "Publish and regularly update an accessibility statement, provide a feedback mechanism, and undergo periodic monitoring by member state authorities",
+        "Submit their source code to the European Commission annually",
+        "Obtain WCAG certification from a private accreditation body",
+        "Require all visitors to complete accessibility training before access is granted"
+      ],
+      correct: 0,
+      explanation: "The Web Accessibility Directive imposes three key procedural obligations on public sector bodies beyond meeting the technical standard: (1) publishing an accessibility statement describing conformance status and known issues, (2) providing a feedback mechanism so users can report barriers and request accessible alternatives, and (3) being subject to periodic monitoring by designated member state authorities who report to the European Commission.",
+      wrongExplanations: {
+        1: "WAD does not require source code submission to the Commission.",
+        2: "WCAG is not a certifiable standard, and WAD does not require private certification.",
+        3: "WAD aims to remove barriers for users, not impose training requirements on them."
+      },
+      topicLinks: ['eu-accessibility'],
+      difficulty: 'hard',
+      tags: ['european-regulations', 'wad']
+    },
+    {
+      id: 377,
+      question: "Which harmonized European standard is referenced by both the Web Accessibility Directive and the European Accessibility Act as the technical conformance baseline for ICT accessibility?",
+      options: [
+        "EN 301 549",
+        "EN 17161",
+        "ISO/IEC 40500",
+        "EN 15838"
+      ],
+      correct: 0,
+      explanation: "EN 301 549 ('Accessibility requirements for ICT products and services') is the harmonized European standard that both WAD and EAA reference for technical conformance. It incorporates WCAG success criteria for web content and adds requirements for non-web software, hardware, documentation, and support services. EN 301 549 is maintained jointly by ETSI, CEN, and CENELEC.",
+      wrongExplanations: {
+        1: "EN 17161 is the Design for All process/management standard — not the technical conformance standard referenced by WAD/EAA.",
+        2: "ISO/IEC 40500 is the ISO-adopted version of WCAG 2.0, but the harmonized standard referenced by EU directives is EN 301 549 (which in turn incorporates WCAG).",
+        3: "EN 15838 is unrelated — it concerns customer contact centres."
+      },
+      topicLinks: ['en-301-549', 'eu-accessibility'],
+      difficulty: 'easy',
+      tags: ['european-regulations', 'en-301-549']
+    },
+    {
+      id: 378,
+      question: "The European Accessibility Act (EAA) took effect as EU law in 2019, but most of its substantive accessibility obligations for covered products and services became applicable on which date?",
+      options: [
+        "28 June 2025",
+        "28 June 2019",
+        "1 January 2021",
+        "28 June 2030"
+      ],
+      correct: 0,
+      explanation: "The European Accessibility Act (Directive (EU) 2019/882) entered into force in 2019, but member states had until 28 June 2022 to transpose it into national law, and the accessibility requirements for covered products and services became applicable on 28 June 2025. Some transitional provisions extend certain deadlines (e.g., for service providers continuing to use products that were lawfully used before the date, and for self-service terminals), but 28 June 2025 is the headline application date.",
+      wrongExplanations: {
+        1: "28 June 2019 is approximately when the directive entered into force, but obligations on businesses did not apply from that date — member states were given time to transpose and businesses were given time to comply.",
+        2: "1 January 2021 is not the EAA applicability date.",
+        3: "28 June 2030 is a later milestone for some transitional provisions on self-service terminals placed on the market before 2025, not the main applicability date."
+      },
+      topicLinks: ['eu-accessibility'],
+      difficulty: 'hard',
+      tags: ['european-regulations', 'eaa', 'dates']
+    },
+
+    // ============================================================
+    // ADA TITLES I-V SCENARIOS (379-385)
+    // Targets gap: which Title applies to which situation
+    // ============================================================
+    {
+      id: 379,
+      question: "A qualified job applicant with a disability is denied a position at a company with 20 employees because the employer refuses to consider a reasonable accommodation that would let them perform the essential functions of the role. Which Title of the ADA covers this situation?",
+      options: [
+        "Title I — Employment",
+        "Title II — State and Local Government",
+        "Title III — Public Accommodations",
+        "Title IV — Telecommunications"
+      ],
+      correct: 0,
+      explanation: "Title I of the ADA prohibits employment discrimination against qualified individuals with disabilities by private employers with 15 or more employees (as well as state/local governments, employment agencies, and labor unions). It requires reasonable accommodations that enable qualified individuals to perform the essential functions of a job, unless doing so would cause undue hardship. Title I is enforced by the EEOC.",
+      wrongExplanations: {
+        1: "Title II covers state and local government programs, services, and activities — not private employer discrimination. (Title I does cover government employment, but the situation here describes a private company.)",
+        2: "Title III covers access to places of public accommodation (restaurants, hotels, retail stores, etc.) — not employment.",
+        3: "Title IV covers telecommunications relay services. It does not govern employment."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'easy',
+      tags: ['ada', 'title-i', 'employment']
+    },
+    {
+      id: 380,
+      question: "A person who uses a wheelchair cannot access the city's public library because it has only stair entrances. Which Title of the ADA applies, and what is the obligation?",
+      options: [
+        "Title II — the public library is a state/local government service and must provide program accessibility, ensuring its services, programs, and activities are accessible to people with disabilities",
+        "Title I — public libraries are governed by employment regulations",
+        "Title III — public libraries are places of public accommodation",
+        "Title V — public libraries are covered by miscellaneous provisions"
+      ],
+      correct: 0,
+      explanation: "Public libraries are operated by state or local governments, placing them under Title II of the ADA. Title II requires that all 'services, programs, and activities' of public entities be accessible — this is called 'program accessibility.' Public entities need not make every facility fully accessible if programs can be made accessible through other means (relocation, auxiliary aids, etc.), but access to government services cannot be denied. Title II is enforced by the DOJ.",
+      wrongExplanations: {
+        1: "Title I covers employment discrimination, not public access to government services.",
+        2: "Title III covers PRIVATE entities that operate places of public accommodation (restaurants, hotels, private schools, retail). Government-operated libraries are Title II, not Title III.",
+        3: "Title V (Miscellaneous) contains provisions on retaliation, attorney's fees, and relationships to other laws — it does not govern access to public libraries directly."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'medium',
+      tags: ['ada', 'title-ii', 'program-accessibility']
+    },
+    {
+      id: 381,
+      question: "A privately owned restaurant refuses to make any modifications to accommodate customers with disabilities, claiming the ADA does not apply to private businesses. What Title applies, and what is their obligation?",
+      options: [
+        "Title III — restaurants are places of public accommodation and must remove architectural barriers where removal is 'readily achievable,' and provide auxiliary aids and services unless doing so would be an undue burden or fundamentally alter the service",
+        "Title I — because restaurants employ staff, this is an employment matter",
+        "Title II — restaurants serve the public, so they are public entities",
+        "The ADA does not apply to private businesses"
+      ],
+      correct: 0,
+      explanation: "Title III of the ADA covers 'places of public accommodation' — a defined list of private entities including restaurants, hotels, retail stores, movie theaters, private schools, doctor's offices, and more. Title III requires removing architectural barriers in existing facilities where such removal is 'readily achievable' (easily accomplishable without much difficulty or expense), providing auxiliary aids and services, and ensuring new construction and alterations meet ADA Standards. Defenses include undue burden and fundamental alteration.",
+      wrongExplanations: {
+        1: "Employment is Title I, but this question is about customer access, not employment.",
+        2: "Title II covers PUBLIC (government) entities. A privately owned restaurant is a private entity, so it falls under Title III.",
+        3: "The ADA explicitly applies to private businesses that are places of public accommodation — this is the core scope of Title III."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'medium',
+      tags: ['ada', 'title-iii', 'public-accommodations']
+    },
+    {
+      id: 382,
+      question: "A Deaf person wants to make a phone call to a hearing business, but they cannot use a standard voice telephone. Which Title of the ADA established the requirement for Telecommunications Relay Services (TRS) enabling this kind of communication?",
+      options: [
+        "Title IV — Telecommunications",
+        "Title I — Employment",
+        "Title III — Public Accommodations",
+        "Title V — Miscellaneous"
+      ],
+      correct: 0,
+      explanation: "Title IV of the ADA amended the Communications Act of 1934 to require telephone companies to provide Telecommunications Relay Services (TRS) that enable people who are Deaf, hard of hearing, or who have speech disabilities to communicate by telephone with hearing users. TRS is administered by the FCC. Modern forms include TTY relay, Video Relay Service (VRS), IP Relay, and Captioned Telephone Service.",
+      wrongExplanations: {
+        1: "Title I addresses employment discrimination, not telecommunications infrastructure.",
+        2: "Title III applies to places of public accommodation. While businesses must provide effective communication, the specific requirement for the relay service SYSTEM comes from Title IV.",
+        3: "Title V contains miscellaneous provisions (retaliation, attorney's fees, construction with other laws) — it did not establish TRS."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'medium',
+      tags: ['ada', 'title-iv', 'telecommunications']
+    },
+    {
+      id: 383,
+      question: "An employee who files an ADA discrimination complaint is subsequently fired by their employer in retaliation. Which Title of the ADA provides the prohibition against retaliation and coercion?",
+      options: [
+        "Title V — Miscellaneous Provisions",
+        "Title I — Employment",
+        "Title II — State and Local Government",
+        "Title IV — Telecommunications"
+      ],
+      correct: 0,
+      explanation: "Title V of the ADA contains 'miscellaneous provisions' that apply across the ADA as a whole, including the prohibition on retaliation against any individual who has opposed an act or practice made unlawful by the ADA or who has filed a charge, testified, assisted, or participated in an ADA investigation or proceeding. Title V also covers coercion, interference, and the ADA's relationship to other federal and state laws, as well as attorney's fees provisions.",
+      wrongExplanations: {
+        1: "While the underlying discrimination claim is under Title I, the specific anti-retaliation PROTECTION lives in Title V, which applies across all titles.",
+        2: "Title II covers state/local government programs — not the cross-cutting anti-retaliation rule.",
+        3: "Title IV addresses telecommunications relay services — not retaliation."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'hard',
+      tags: ['ada', 'title-v', 'retaliation']
+    },
+    {
+      id: 384,
+      question: "An employer argues that providing a particular accommodation — a costly workspace renovation and specialized equipment — would cause 'undue hardship' given the company's small size and limited resources. Under ADA Title I, what does 'undue hardship' mean as a defense?",
+      options: [
+        "Significant difficulty or expense when considered in light of factors such as the cost of the accommodation, the employer's overall financial resources, the size of the business, and the impact on operations",
+        "Any inconvenience or cost, regardless of size or amount",
+        "A mere preference by the employer not to provide the accommodation",
+        "An accommodation that would require hiring additional staff"
+      ],
+      correct: 0,
+      explanation: "Under Title I, 'undue hardship' means an action requiring significant difficulty or expense. The EEOC considers several factors: the nature and cost of the accommodation, the financial resources of the facility and the covered entity as a whole, the size and structure of the business, and the impact on operations. It is a high bar — minor inconvenience or modest cost generally does not qualify. If a particular accommodation causes undue hardship, the employer must still consider alternative accommodations that would not.",
+      wrongExplanations: {
+        1: "Any inconvenience is not enough. Undue hardship requires significant difficulty or expense relative to the employer's resources.",
+        2: "Employer preference is never a valid basis for denying an accommodation. The defense is a substantive one based on objective factors.",
+        3: "Accommodations do not generally require hiring additional staff; needing to hire someone to do the essential functions is different from providing an accommodation."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'hard',
+      tags: ['ada', 'title-i', 'undue-hardship']
+    },
+    {
+      id: 385,
+      question: "A website operated by a state university and a website operated by a nationwide private retail chain both have accessibility barriers. Under the ADA, which Titles apply to each, respectively?",
+      options: [
+        "State university website → Title II (public entity); private retail chain website → Title III (public accommodation)",
+        "Both → Title I",
+        "Both → Title III",
+        "State university website → Title III; private retail chain website → Title II"
+      ],
+      correct: 0,
+      explanation: "A state university is an instrumentality of state government and is therefore a public entity covered by Title II. A nationwide private retail chain is a private entity operating places of public accommodation, so its website falls under Title III (DOJ has taken the position that websites of public accommodations are covered, and most federal courts have agreed when there is a sufficient nexus to services). Correctly identifying public versus private status is the first step in determining which ADA Title applies.",
+      wrongExplanations: {
+        1: "Title I addresses employment, not customer-facing website access.",
+        2: "The state university is a public entity covered by Title II, not Title III.",
+        3: "This reverses the categories. Public (government) entities are Title II; private places of public accommodation are Title III."
+      },
+      topicLinks: ['ada'],
+      difficulty: 'medium',
+      tags: ['ada', 'title-ii', 'title-iii', 'websites']
     }
   ]
 };

--- a/src/data/questions/was-domain1.js
+++ b/src/data/questions/was-domain1.js
@@ -1,10 +1,10 @@
 export const wasDomain1 = {
   id: 'was-domain1',
   courseId: 'was',
-  title: 'WCAG Principles & Success Criteria',
+  title: 'Creating Accessible Web Solutions',
   iconName: 'code',
   color: 'bg-indigo-600',
-  description: 'WCAG structure, specific success criteria, conformance levels, and techniques.',
+  description: 'WCAG, ARIA, progressive enhancement, SPAs, and building accessible UI components.',
   questions: [
     // =============================================
     // WCAG STRUCTURE & CONFORMANCE (1001-1010)
@@ -1148,6 +1148,501 @@ export const wasDomain1 = {
       topicLinks: ['wcag-robust'],
       difficulty: 'hard',
       tags: ['wcag-robust']
+    },
+    // =============================================
+    // GUIDELINES BEYOND WCAG (1057-1062)
+    // =============================================
+    {
+      id: 1057,
+      question: "What is the primary scope of ATAG 2.0 (Authoring Tool Accessibility Guidelines)?",
+      options: [
+        "Making authoring tool user interfaces accessible AND supporting the production of accessible content",
+        "Providing success criteria for evaluating web content conformance",
+        "Defining accessibility requirements for assistive technologies",
+        "Specifying how browsers should expose the accessibility tree"
+      ],
+      correct: 0,
+      explanation: "ATAG 2.0 has two parts: Part A requires the authoring tool's own UI to be accessible, and Part B requires the tool to support authors in producing accessible output (e.g., prompting for alt text).",
+      wrongExplanations: {
+        1: "Evaluating web content against success criteria is the role of WCAG, not ATAG.",
+        2: "Guidelines for assistive technologies themselves are outside ATAG's scope; ATAG targets content creation tools.",
+        3: "Accessibility tree exposure is a browser/platform concern covered by Core-AAM and related specs, not ATAG."
+      },
+      topicLinks: ['atag-overview', 'wcag-overview'],
+      difficulty: 'medium',
+      tags: ['standards', 'atag']
+    },
+    {
+      id: 1058,
+      question: "A European public sector site must comply with EN 301 549. Which statement best describes its relationship to WCAG?",
+      options: [
+        "EN 301 549 incorporates WCAG as its requirements for web content while covering additional ICT like software, documents, and hardware",
+        "EN 301 549 replaces WCAG entirely in the European Union",
+        "EN 301 549 applies only to native mobile applications, not websites",
+        "EN 301 549 is an older standard that has been deprecated in favor of WCAG 2.2"
+      ],
+      correct: 0,
+      explanation: "EN 301 549 is the European harmonized ICT accessibility standard. For web content it incorporates WCAG 2.1 Level AA by reference, but it also covers non-web software, documents, hardware, and support services.",
+      wrongExplanations: {
+        1: "EN 301 549 uses WCAG for its web requirements rather than replacing it.",
+        2: "EN 301 549 covers a broad range of ICT, including websites, not just mobile apps.",
+        3: "EN 301 549 is active and updated regularly; it is not deprecated."
+      },
+      topicLinks: ['en-301-549', 'wcag-overview'],
+      difficulty: 'medium',
+      tags: ['standards', 'en-301-549']
+    },
+    {
+      id: 1059,
+      question: "What does the WAI-ARIA 1.2 specification primarily define?",
+      options: [
+        "Roles, states, and properties that communicate semantics of UI components to assistive technologies",
+        "Visual design patterns for accessible user interfaces",
+        "Keyboard shortcut standards for web applications",
+        "Color contrast ratios for text and UI components"
+      ],
+      correct: 0,
+      explanation: "WAI-ARIA defines a vocabulary of roles, states, and properties that authors can add to markup so custom widgets and dynamic content expose proper semantics to assistive technologies.",
+      wrongExplanations: {
+        1: "ARIA is a semantics specification, not a visual design system.",
+        2: "Keyboard interaction patterns are described in the ARIA Authoring Practices Guide, which is informative and separate from the normative ARIA spec.",
+        3: "Color contrast requirements are defined in WCAG success criteria, not in the ARIA spec."
+      },
+      topicLinks: ['aria-overview', 'aria-roles', 'aria-states-properties'],
+      difficulty: 'easy',
+      tags: ['standards', 'aria']
+    },
+    {
+      id: 1060,
+      question: "Which statement best reflects the first rule of ARIA?",
+      options: [
+        "If a native HTML element or attribute with the semantics you need already exists, use it instead of ARIA",
+        "Always add an ARIA role to every interactive element",
+        "Never use ARIA on form controls",
+        "ARIA roles should always be combined with role='presentation'"
+      ],
+      correct: 0,
+      explanation: "The first rule of ARIA is: don't use ARIA if a native HTML element provides the needed semantics and behavior. Native elements are better supported and come with built-in keyboard and focus behavior.",
+      wrongExplanations: {
+        1: "Blanket addition of ARIA roles is an anti-pattern; ARIA should supplement, not replace, semantic HTML.",
+        2: "ARIA can legitimately augment form controls (e.g., aria-describedby for errors).",
+        3: "Combining widget roles with role='presentation' would remove the very semantics you just added — this is incorrect."
+      },
+      topicLinks: ['aria-overview', 'semantic-html'],
+      difficulty: 'easy',
+      tags: ['aria', 'semantic-html']
+    },
+    {
+      id: 1061,
+      question: "An authoring tool prompts the user to add alt text whenever an image is inserted. Which part of ATAG 2.0 does this support?",
+      options: [
+        "Part B — supporting the production of accessible content",
+        "Part A — making the tool's own UI accessible",
+        "Neither; this is a WCAG requirement, not ATAG",
+        "Both parts equally, since they have identical requirements"
+      ],
+      correct: 0,
+      explanation: "ATAG Part B addresses how the tool helps authors produce accessible content. Prompting for alt text is a classic Part B support feature.",
+      wrongExplanations: {
+        1: "Part A is about the accessibility of the authoring tool interface itself (menus, dialogs), not the content produced.",
+        2: "WCAG applies to the output content; ATAG applies to the authoring tool and how it supports accessible creation.",
+        3: "Parts A and B have distinct requirements and scopes."
+      },
+      topicLinks: ['atag-overview'],
+      difficulty: 'medium',
+      tags: ['atag']
+    },
+    {
+      id: 1062,
+      question: "A team must conform to WCAG 2.1 Level AA. Must they also meet Level A success criteria?",
+      options: [
+        "Yes — Level AA conformance requires meeting all Level A and Level AA success criteria",
+        "No — Level AA replaces Level A requirements entirely",
+        "Only if the content is for a government site",
+        "Only the Level A criteria marked as 'essential' must be met"
+      ],
+      correct: 0,
+      explanation: "WCAG conformance levels are cumulative. Level AA conformance requires satisfying all Level A criteria plus all Level AA criteria. Level AAA further requires all A, AA, and AAA criteria.",
+      wrongExplanations: {
+        1: "Levels are additive, not replacements.",
+        2: "The cumulative rule applies to any WCAG conformance claim, not just government sites.",
+        3: "There is no subset of 'essential' Level A criteria — all Level A SC must be met for Level AA."
+      },
+      topicLinks: ['wcag-overview'],
+      difficulty: 'easy',
+      tags: ['wcag-structure', 'conformance']
+    },
+    // =============================================
+    // JAVASCRIPT & DYNAMIC CONTENT (1063-1068)
+    // =============================================
+    {
+      id: 1063,
+      question: "What is the core idea of progressive enhancement in the context of accessible JavaScript?",
+      options: [
+        "Start with a working HTML baseline, then layer CSS and JavaScript so the experience degrades gracefully when scripts fail or are unsupported",
+        "Write JavaScript first and add HTML only as a fallback",
+        "Use only the latest JavaScript features and require modern browsers",
+        "Replace all HTML forms with JavaScript-driven custom components"
+      ],
+      correct: 0,
+      explanation: "Progressive enhancement starts with semantic HTML that works on its own, then enhances it with CSS and JavaScript. If JS fails or is blocked, core functionality remains accessible.",
+      wrongExplanations: {
+        1: "This inverts the principle — HTML is the baseline, not the fallback.",
+        2: "Progressive enhancement specifically avoids cutting off older or constrained environments.",
+        3: "Replacing native controls with custom ones typically reduces accessibility, the opposite of the goal."
+      },
+      topicLinks: ['javascript-accessibility', 'semantic-html'],
+      difficulty: 'easy',
+      tags: ['javascript', 'progressive-enhancement']
+    },
+    {
+      id: 1064,
+      question: "A developer attaches an onclick handler to a <div> to make it act as a button. What is the minimum set of changes needed to make it accessible?",
+      options: [
+        "Add role='button', tabindex='0', and handle both Enter and Space key events — or better yet, use a native <button> element",
+        "Only add role='button'; screen readers will handle the rest",
+        "Only add tabindex='0'; that is sufficient for keyboard users",
+        "Add aria-label='button'; no keyboard handling is required"
+      ],
+      correct: 0,
+      explanation: "Mimicking a button with a div requires role='button' for semantics, tabindex='0' for keyboard focus, AND key handlers for Enter/Space. The better solution is to use <button>, which provides all of this natively.",
+      wrongExplanations: {
+        1: "Role alone doesn't make the element focusable or operable with the keyboard.",
+        2: "Tabindex makes it focusable but doesn't convey button semantics or handle activation keys.",
+        3: "aria-label provides an accessible name but does not provide role, focus, or key handling."
+      },
+      topicLinks: ['javascript-accessibility', 'standard-vs-custom-controls', 'semantic-html'],
+      difficulty: 'medium',
+      tags: ['javascript', 'keyboard', 'custom-controls']
+    },
+    {
+      id: 1065,
+      question: "A modal dialog opens after the user clicks a button. Where should keyboard focus go, and where should it return when the dialog closes?",
+      options: [
+        "Focus should move into the dialog (typically to the first focusable element or the dialog container) and return to the triggering button when closed",
+        "Focus should remain on the triggering button while the dialog is open",
+        "Focus should jump to the footer of the page when the dialog opens",
+        "Focus management is optional; screen readers handle it automatically"
+      ],
+      correct: 0,
+      explanation: "When a dialog opens, focus must move into it so keyboard and screen reader users can interact with it. On close, focus returns to the element that triggered the dialog so users don't lose their place.",
+      wrongExplanations: {
+        1: "Leaving focus on the trigger strands keyboard users outside the dialog.",
+        2: "Jumping to an unrelated location disorients users.",
+        3: "Dialogs do not get automatic focus handling; it must be implemented by the author."
+      },
+      topicLinks: ['javascript-accessibility', 'aria-states-properties'],
+      difficulty: 'medium',
+      tags: ['javascript', 'focus-management', 'dialogs']
+    },
+    {
+      id: 1066,
+      question: "An autocomplete widget inserts new suggestions into the DOM as the user types. How should updates be announced to screen reader users without stealing focus?",
+      options: [
+        "Use an ARIA live region (or a combobox pattern with aria-live) so assistive technologies announce changes automatically",
+        "Call element.focus() on each new suggestion as it appears",
+        "Use alert() to announce new suggestions",
+        "Rely on the browser to automatically speak new DOM nodes"
+      ],
+      correct: 0,
+      explanation: "Dynamic content updates that should be announced without interrupting the user's input must be placed in an ARIA live region. The combobox pattern also uses aria-activedescendant to virtually track the current option without moving focus.",
+      wrongExplanations: {
+        1: "Moving focus on every keystroke would disrupt typing and is disorienting.",
+        2: "alert() is a modal browser dialog, not an accessibility feature, and it breaks the user flow.",
+        3: "Browsers do not automatically announce arbitrary DOM insertions."
+      },
+      topicLinks: ['aria-live-regions', 'javascript-accessibility'],
+      difficulty: 'medium',
+      tags: ['javascript', 'aria-live', 'dynamic-content']
+    },
+    {
+      id: 1067,
+      question: "Which ARIA attribute correctly conveys the expanded/collapsed state of a disclosure button?",
+      options: [
+        "aria-expanded='true' or aria-expanded='false' on the button",
+        "aria-hidden on the button, toggled true/false",
+        "aria-pressed on the button",
+        "role='toggle' on the button"
+      ],
+      correct: 0,
+      explanation: "aria-expanded on the trigger button communicates whether the disclosed region is currently visible. It must be updated in JavaScript whenever the state changes.",
+      wrongExplanations: {
+        1: "aria-hidden removes an element from the accessibility tree — it does not communicate expanded state.",
+        2: "aria-pressed is for toggle buttons (like bold/italic), not disclosure widgets.",
+        3: "There is no standard role='toggle' in ARIA."
+      },
+      topicLinks: ['aria-states-properties', 'javascript-accessibility'],
+      difficulty: 'easy',
+      tags: ['aria', 'aria-states']
+    },
+    {
+      id: 1068,
+      question: "A developer uses element.innerHTML to replace large sections of the page after an AJAX call. What's the main accessibility risk?",
+      options: [
+        "Focus can be lost if the focused element is removed, leaving keyboard users stranded and screen reader users without context",
+        "innerHTML is always forbidden by WCAG",
+        "Screen readers cannot read content inserted with innerHTML",
+        "Content inserted with innerHTML is automatically marked aria-hidden"
+      ],
+      correct: 0,
+      explanation: "Replacing DOM subtrees can destroy the element that currently has focus, sending focus to document.body. Developers must save and restore focus (or move it to a sensible destination) and notify users of the change.",
+      wrongExplanations: {
+        1: "WCAG does not forbid any specific DOM API; it targets outcomes.",
+        2: "Screen readers read whatever is in the accessibility tree, regardless of how it got there.",
+        3: "innerHTML does not apply any ARIA attributes automatically."
+      },
+      topicLinks: ['javascript-accessibility', 'spa-accessibility'],
+      difficulty: 'hard',
+      tags: ['javascript', 'focus-management']
+    },
+    // =============================================
+    // STANDARD VS. CUSTOM CONTROLS (1069-1074)
+    // =============================================
+    {
+      id: 1069,
+      question: "Which of the following does a native <button> element provide 'for free' that a custom div-based button must manually implement?",
+      options: [
+        "Focusability, button role, Enter/Space activation, and form submission behavior",
+        "Only focus ring styling",
+        "Only the button role; keyboard handling must still be added",
+        "Nothing — native buttons and divs behave identically"
+      ],
+      correct: 0,
+      explanation: "Native <button> elements are focusable by default, expose the button role, respond to Enter and Space, participate in forms, and respect disabled state — all automatically.",
+      wrongExplanations: {
+        1: "Focus ring is only one small aspect; native buttons provide much more.",
+        2: "Native buttons fully handle Enter and Space activation with no scripting required.",
+        3: "Divs and buttons differ substantially in default semantics and behavior."
+      },
+      topicLinks: ['standard-vs-custom-controls', 'semantic-html'],
+      difficulty: 'easy',
+      tags: ['semantic-html', 'custom-controls']
+    },
+    {
+      id: 1070,
+      question: "When is building a custom ARIA widget justified instead of using native HTML?",
+      options: [
+        "When no native element provides the needed interaction pattern (e.g., a tree view or a tab interface)",
+        "Any time a designer wants unique visual styling",
+        "Whenever the team is more comfortable with JavaScript than HTML",
+        "Whenever the page already uses a JavaScript framework"
+      ],
+      correct: 0,
+      explanation: "Custom ARIA widgets are justified only when no native equivalent exists — such as tablist, tree, or combobox. Otherwise, styled native elements should be preferred.",
+      wrongExplanations: {
+        1: "Styling requirements can almost always be met by styling native elements.",
+        2: "Team comfort is not a valid accessibility justification.",
+        3: "Framework usage doesn't require abandoning native semantics."
+      },
+      topicLinks: ['standard-vs-custom-controls', 'aria-overview'],
+      difficulty: 'medium',
+      tags: ['custom-controls', 'aria']
+    },
+    {
+      id: 1071,
+      question: "A designer wants a styled checkbox with a custom checkmark animation. What is the most accessible implementation?",
+      options: [
+        "Use a real <input type='checkbox'>, visually hide it, and style an adjacent element — the native input retains all semantics and keyboard behavior",
+        "Use a <div role='checkbox'> with tabindex='0' and manually handle space/enter keys",
+        "Use an <img> of a checkbox with an onclick handler",
+        "Use a <button> with the text 'checked' or 'unchecked'"
+      ],
+      correct: 0,
+      explanation: "Visually hiding the real checkbox (but keeping it in the accessibility tree and focusable) and styling a sibling element is a robust pattern. The native input retains all keyboard, form, and AT behavior.",
+      wrongExplanations: {
+        1: "This works but requires re-implementing everything the native input already provides, increasing risk.",
+        2: "An image with onclick has no role, state, or keyboard support.",
+        3: "A button doesn't naturally convey checked/unchecked state or participate in forms."
+      },
+      topicLinks: ['standard-vs-custom-controls', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['custom-controls', 'forms']
+    },
+    {
+      id: 1072,
+      question: "Which ARIA pattern is appropriate for a set of mutually exclusive selectable options where only one can be active at a time and arrow keys navigate between them?",
+      options: [
+        "role='radiogroup' containing role='radio' elements — or native radio inputs",
+        "role='button' on each option",
+        "role='checkbox' on each option",
+        "role='listbox' with role='option' and aria-multiselectable='true'"
+      ],
+      correct: 0,
+      explanation: "Mutually exclusive single-choice selection is the radio group pattern. Native <input type='radio'> elements give all this behavior for free; ARIA radiogroup is used when building custom widgets.",
+      wrongExplanations: {
+        1: "Buttons don't convey single-selection state.",
+        2: "Checkboxes represent independent on/off state, not mutually exclusive choices.",
+        3: "Multiselectable='true' allows multiple selections, which is the opposite of mutually exclusive."
+      },
+      topicLinks: ['aria-roles', 'standard-vs-custom-controls'],
+      difficulty: 'medium',
+      tags: ['aria', 'forms']
+    },
+    {
+      id: 1073,
+      question: "Which is NOT a requirement when building a custom ARIA slider widget?",
+      options: [
+        "Use <div role='presentation'> to hide its role from assistive technology",
+        "Expose aria-valuenow, aria-valuemin, and aria-valuemax",
+        "Support arrow keys to increase/decrease the value",
+        "Provide an accessible name via aria-label or aria-labelledby"
+      ],
+      correct: 0,
+      explanation: "A slider must expose role='slider' to assistive technologies, along with its current, min, and max values, keyboard operability, and an accessible name. Hiding its role defeats the entire purpose.",
+      wrongExplanations: {
+        1: "These are required slider value properties.",
+        2: "Keyboard operability is a required part of the slider pattern.",
+        3: "A slider needs an accessible name to communicate what it controls."
+      },
+      topicLinks: ['aria-roles', 'aria-states-properties', 'standard-vs-custom-controls'],
+      difficulty: 'hard',
+      tags: ['aria', 'custom-controls']
+    },
+    {
+      id: 1074,
+      question: "What does the phrase 'no ARIA is better than bad ARIA' mean in practice?",
+      options: [
+        "Incorrect ARIA usage can mislead assistive technologies more than using plain (even if imperfect) HTML",
+        "ARIA should never be used on any website",
+        "ARIA only works in certain browsers so it should be avoided",
+        "Plain HTML is always fully accessible without ARIA"
+      ],
+      correct: 0,
+      explanation: "Incorrect ARIA (wrong role, conflicting states, redundant attributes) actively misleads assistive technologies, often producing worse outcomes than no ARIA at all. The guidance encourages caution and correctness.",
+      wrongExplanations: {
+        1: "ARIA is essential for many custom patterns; the warning is about misuse, not use.",
+        2: "ARIA has broad support across modern assistive technologies.",
+        3: "Plain HTML can still have accessibility gaps — ARIA exists to fill them when used correctly."
+      },
+      topicLinks: ['aria-overview', 'semantic-html'],
+      difficulty: 'medium',
+      tags: ['aria']
+    },
+    // =============================================
+    // SPA ACCESSIBILITY (1075-1078)
+    // =============================================
+    {
+      id: 1075,
+      question: "In a single page application using client-side routing, what accessibility problem commonly occurs after a route change?",
+      options: [
+        "Screen readers aren't notified of the new view, focus remains in the previous view, and the page title doesn't update",
+        "CSS files fail to load",
+        "Keyboard shortcuts stop working permanently",
+        "Browser history becomes inaccessible"
+      ],
+      correct: 0,
+      explanation: "Because no full page load occurs, assistive technology isn't automatically notified. Developers must manually update the document title, move focus (commonly to the new main heading), and optionally announce the change in a live region.",
+      wrongExplanations: {
+        1: "CSS loading isn't inherently affected by client-side routing.",
+        2: "Keyboard shortcuts aren't automatically broken by routing.",
+        3: "Browser history remains accessible; routers typically integrate with the History API."
+      },
+      topicLinks: ['spa-accessibility', 'javascript-accessibility'],
+      difficulty: 'medium',
+      tags: ['spa', 'routing']
+    },
+    {
+      id: 1076,
+      question: "Which pattern is commonly recommended for handling focus after a route change in a SPA?",
+      options: [
+        "Move focus to the new view's main heading (h1) or a container with tabindex='-1' and focus it programmatically",
+        "Return focus to the browser URL bar",
+        "Leave focus where it was; SPA routing should be invisible",
+        "Focus the body element and let the user Tab from the top"
+      ],
+      correct: 0,
+      explanation: "Focusing the new view's h1 (or a wrapper with tabindex='-1') signals the context change to screen readers and gives keyboard users a sensible starting point in the new content.",
+      wrongExplanations: {
+        1: "The URL bar is outside the document and can't be programmatically focused by scripts.",
+        2: "Leaving focus strands keyboard users in stale content.",
+        3: "document.body doesn't communicate any context about the new view."
+      },
+      topicLinks: ['spa-accessibility', 'javascript-accessibility'],
+      difficulty: 'medium',
+      tags: ['spa', 'focus-management']
+    },
+    {
+      id: 1077,
+      question: "Why should a SPA update document.title on each route change?",
+      options: [
+        "Screen readers announce the document title on navigation, and it populates browser history/tab labels for all users",
+        "Because WCAG requires titles to rotate every 30 seconds",
+        "To improve JavaScript performance",
+        "Because document.title is required for valid HTML5"
+      ],
+      correct: 0,
+      explanation: "SC 2.4.2 (Page Titled) requires each view to have a descriptive title. In a SPA, updating document.title ensures each route behaves like a titled page for assistive technologies, browser history, and bookmarks.",
+      wrongExplanations: {
+        1: "WCAG has no such rotating requirement.",
+        2: "Document titles have no direct performance impact.",
+        3: "HTML5 requires <title> once in the document; this is about conveying the current view."
+      },
+      topicLinks: ['spa-accessibility', 'wcag-operable'],
+      difficulty: 'medium',
+      tags: ['spa', 'wcag-operable']
+    },
+    {
+      id: 1078,
+      question: "A SPA uses an aria-live='polite' region to announce 'Page loaded: Dashboard' after each route change. What is a potential drawback of this approach alone?",
+      options: [
+        "Without also moving focus, keyboard users are still stranded in the old view even though screen readers announce the change",
+        "Polite live regions never actually speak in any screen reader",
+        "aria-live is not supported in any modern browser",
+        "Live regions interfere with the browser's back button"
+      ],
+      correct: 0,
+      explanation: "Live region announcements alone address the 'did something change?' question but don't reposition keyboard focus. Best practice combines an announcement with focus management to the new view.",
+      wrongExplanations: {
+        1: "Polite live regions are widely supported and announce when the user is idle.",
+        2: "aria-live is well supported across browsers and assistive technology.",
+        3: "Live regions don't affect browser history or navigation controls."
+      },
+      topicLinks: ['aria-live-regions', 'spa-accessibility'],
+      difficulty: 'hard',
+      tags: ['spa', 'aria-live']
+    },
+    // =============================================
+    // USER STRATEGIES (1079-1080)
+    // =============================================
+    {
+      id: 1079,
+      question: "A blind screen reader user typically navigates a web page first by which strategy?",
+      options: [
+        "Pulling up a list of headings or landmarks to get an overview, then jumping to a section of interest",
+        "Reading every word from the top of the page to the bottom without exception",
+        "Using a mouse to click on areas of interest",
+        "Requesting a sighted assistant to describe the page"
+      ],
+      correct: 0,
+      explanation: "Experienced screen reader users rely on structural shortcuts: heading lists, landmark navigation, and link/form lists let them build a mental model of a page quickly rather than reading linearly.",
+      wrongExplanations: {
+        1: "Linear reading is slow and is usually a fallback, not a primary strategy.",
+        2: "Blind users typically do not use a mouse.",
+        3: "Screen reader users navigate independently; sighted assistance is not a browsing strategy."
+      },
+      topicLinks: ['disability-user-strategies', 'screen-readers'],
+      difficulty: 'easy',
+      tags: ['user-strategies', 'screen-readers']
+    },
+    {
+      id: 1080,
+      question: "Which accommodation is most commonly used by a low-vision user who can still use a mouse and see the screen?",
+      options: [
+        "Browser zoom, OS-level magnification, and/or high contrast themes",
+        "A refreshable braille display",
+        "Switch devices operated by head movement",
+        "Sign language interpretation"
+      ],
+      correct: 0,
+      explanation: "Low-vision users commonly rely on zoom (browser or OS), screen magnifiers, and high-contrast color schemes. Designs must accommodate these by supporting reflow at 400% zoom and not breaking under custom stylesheets.",
+      wrongExplanations: {
+        1: "Braille displays are used by blind users, typically with a screen reader, not by sighted low-vision users.",
+        2: "Switch devices are used by people with significant motor impairments.",
+        3: "Sign language interpretation supports Deaf users, not low-vision users."
+      },
+      topicLinks: ['disability-user-strategies'],
+      difficulty: 'easy',
+      tags: ['user-strategies', 'low-vision']
     }
   ]
 };

--- a/src/data/questions/was-domain2.js
+++ b/src/data/questions/was-domain2.js
@@ -1,10 +1,10 @@
 export const wasDomain2 = {
   id: 'was-domain2',
   courseId: 'was',
-  title: 'ARIA, Semantics & Implementation',
+  title: 'Identifying Accessibility Issues',
   iconName: 'code',
   color: 'bg-teal-600',
-  description: 'HTML semantics, ARIA roles and properties, accessible patterns, and testing.',
+  description: 'Accessibility tree, accessible names, WCAG-EM, ACT rules, testing strategies, and QA.',
   questions: [
     // =============================================
     // SEMANTIC HTML (1101-1115)
@@ -1016,6 +1016,624 @@ export const wasDomain2 = {
       topicLinks: ['wcag-perceivable', 'wcag-overview'],
       difficulty: 'easy',
       tags: ['testing', 'color-contrast', 'tools']
+    },
+    // =============================================
+    // ACCESSIBILITY TREE & INTEROPERABILITY (1151-1156)
+    // =============================================
+    {
+      id: 1151,
+      question: "What is the accessibility tree?",
+      options: [
+        "A parallel structure derived from the DOM that browsers expose to assistive technologies, containing accessible objects with name, role, state, and value",
+        "A visual tree of DOM nodes shown in the browser's Elements panel",
+        "A JavaScript API for measuring page performance",
+        "A hierarchical map of CSS cascade order"
+      ],
+      correct: 0,
+      explanation: "The accessibility tree is a browser-constructed representation based on the DOM (and CSS) that exposes accessible objects — each with name, role, state, and value — through platform accessibility APIs that assistive technology consumes.",
+      wrongExplanations: {
+        1: "That describes the DOM tree in DevTools, which is different from the accessibility tree.",
+        2: "Performance APIs are unrelated to accessibility exposure.",
+        3: "The cascade determines styling, not AT semantics."
+      },
+      topicLinks: ['accessibility-tree'],
+      difficulty: 'medium',
+      tags: ['accessibility-tree', 'assistive-tech']
+    },
+    {
+      id: 1152,
+      question: "Which CSS property typically removes an element from the accessibility tree in addition to hiding it visually?",
+      options: [
+        "display: none",
+        "visibility: visible",
+        "opacity: 0.5",
+        "color: transparent"
+      ],
+      correct: 0,
+      explanation: "Elements with display: none (or visibility: hidden) are excluded from both the rendered output and the accessibility tree. Opacity and transparent color hide content visually but leave it exposed to assistive technology.",
+      wrongExplanations: {
+        1: "visibility: visible keeps the element visible and in the tree — that's the default state.",
+        2: "Opacity affects visual rendering only; content remains in the accessibility tree.",
+        3: "Transparent text is still present in the accessibility tree."
+      },
+      topicLinks: ['accessibility-tree'],
+      difficulty: 'medium',
+      tags: ['accessibility-tree', 'css']
+    },
+    {
+      id: 1153,
+      question: "Why is it important to test with specific browser + screen reader combinations (e.g., NVDA + Firefox, JAWS + Chrome, VoiceOver + Safari)?",
+      options: [
+        "Because the way browsers build the accessibility tree and map it to platform APIs varies, and screen readers rely on those mappings differently",
+        "Because WCAG requires testing in every possible browser",
+        "Because screen readers refuse to run in certain browsers",
+        "Because only specific browsers support ARIA at all"
+      ],
+      correct: 0,
+      explanation: "Browsers and screen readers combine to form an interoperability layer. Subtle differences in how each browser maps the DOM to the accessibility tree, and how each screen reader interprets it, can produce real variations in user experience.",
+      wrongExplanations: {
+        1: "WCAG does not mandate testing in every browser combination.",
+        2: "Most screen readers run in most browsers, though with different levels of compatibility.",
+        3: "ARIA is supported across all major browsers."
+      },
+      topicLinks: ['accessibility-tree', 'screen-reader-testing'],
+      difficulty: 'medium',
+      tags: ['testing', 'assistive-tech']
+    },
+    {
+      id: 1154,
+      question: "Which browser DevTools feature can you use to inspect the computed accessible name, role, and state of an element?",
+      options: [
+        "The Accessibility panel (or Accessibility pane within Elements) in Chrome, Firefox, and Edge DevTools",
+        "The Network panel",
+        "The Performance panel",
+        "The Sources panel"
+      ],
+      correct: 0,
+      explanation: "Modern browsers include an Accessibility pane in DevTools that shows the element's computed accessible name, role, states, and properties based on the accessibility tree.",
+      wrongExplanations: {
+        1: "Network monitors HTTP traffic.",
+        2: "Performance profiles runtime activity.",
+        3: "Sources manages scripts and debugging."
+      },
+      topicLinks: ['accessibility-tree', 'automated-testing-tools'],
+      difficulty: 'easy',
+      tags: ['testing', 'devtools']
+    },
+    {
+      id: 1155,
+      question: "A screen reader reads a button as 'Submit form button' even though its visible text is only 'Submit'. Why might this happen?",
+      options: [
+        "An aria-label or aria-labelledby is overriding the visible text with a longer accessible name",
+        "Screen readers always append 'form button' to every button",
+        "The browser's spell-check is inserting additional words",
+        "The CSS content property is leaking into the accessibility tree"
+      ],
+      correct: 0,
+      explanation: "When aria-label or aria-labelledby is set, it takes precedence over the visible text content per the accessible name computation algorithm. This can cause a mismatch with visible content (and may also fail SC 2.5.3 Label in Name).",
+      wrongExplanations: {
+        1: "Screen readers don't append arbitrary words to button names.",
+        2: "Spell-check doesn't affect accessible names.",
+        3: "CSS generated content can affect the accessibility tree in some browsers, but aria-label is the far more common cause."
+      },
+      topicLinks: ['accessible-names-descriptions', 'accessibility-tree'],
+      difficulty: 'hard',
+      tags: ['accessible-names', 'aria']
+    },
+    {
+      id: 1156,
+      question: "Which element is NOT typically included in a page's accessibility tree?",
+      options: [
+        "An element with aria-hidden='true' (and no focusable descendants)",
+        "A button with only an aria-label",
+        "An <h1> with visible text",
+        "A <nav> landmark"
+      ],
+      correct: 0,
+      explanation: "aria-hidden='true' explicitly removes an element and its subtree from the accessibility tree, making it invisible to assistive technology. Using it on an element containing focusable children is an anti-pattern.",
+      wrongExplanations: {
+        1: "A button with aria-label is fully exposed with its computed name.",
+        2: "Headings are exposed with their accessible name and heading role.",
+        3: "Landmarks like <nav> are exposed with landmark roles."
+      },
+      topicLinks: ['accessibility-tree', 'aria-states-properties'],
+      difficulty: 'medium',
+      tags: ['accessibility-tree', 'aria']
+    },
+    // =============================================
+    // ACCESSIBLE NAMES & DESCRIPTIONS (1157-1162)
+    // =============================================
+    {
+      id: 1157,
+      question: "According to the accessible name computation algorithm, which source has the HIGHEST precedence for a form input?",
+      options: [
+        "aria-labelledby",
+        "aria-label",
+        "An associated <label> element",
+        "The title attribute"
+      ],
+      correct: 0,
+      explanation: "The name computation order is roughly: aria-labelledby > aria-label > native labeling (like <label>) > title. aria-labelledby wins because it allows referencing visible text elsewhere on the page.",
+      wrongExplanations: {
+        1: "aria-label is used only when aria-labelledby is not present.",
+        2: "Native <label> is used when neither aria-labelledby nor aria-label are present.",
+        3: "The title attribute is a last-resort fallback and is discouraged due to poor discoverability."
+      },
+      topicLinks: ['accessible-names-descriptions', 'form-accessibility'],
+      difficulty: 'hard',
+      tags: ['accessible-names']
+    },
+    {
+      id: 1158,
+      question: "When should you use aria-describedby instead of aria-label or aria-labelledby?",
+      options: [
+        "To provide additional description (like help text or error messages) that supplements — but does not replace — the accessible name",
+        "To provide the primary accessible name when no visible label exists",
+        "To hide an element from assistive technology",
+        "To set the role of an element"
+      ],
+      correct: 0,
+      explanation: "aria-describedby provides an accessible description: extra context like help text, format hints, or error messages. It is appended to the accessible name announcement, not a replacement for it.",
+      wrongExplanations: {
+        1: "That is the job of aria-labelledby or aria-label.",
+        2: "Hiding is done with aria-hidden.",
+        3: "Roles are set with the role attribute or native semantics."
+      },
+      topicLinks: ['accessible-names-descriptions', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['accessible-names']
+    },
+    {
+      id: 1159,
+      question: "Which markup gives an icon-only button the best accessible name?",
+      options: [
+        "<button aria-label='Close dialog'><svg aria-hidden='true'>…</svg></button>",
+        "<button><svg><title>x</title></svg></button>",
+        "<button><svg></svg></button>",
+        "<div onclick='close()'><svg></svg></div>"
+      ],
+      correct: 0,
+      explanation: "For an icon-only button, aria-label provides a clear accessible name while aria-hidden on the decorative SVG prevents duplicate announcements. The <button> element ensures role, focus, and keyboard behavior come for free.",
+      wrongExplanations: {
+        1: "A bare 'x' inside a <title> is unclear and may or may not become the accessible name depending on the browser.",
+        2: "The button has no accessible name at all.",
+        3: "A div has no role, is not focusable, and has no accessible name."
+      },
+      topicLinks: ['accessible-names-descriptions', 'semantic-html'],
+      difficulty: 'medium',
+      tags: ['accessible-names', 'icons']
+    },
+    {
+      id: 1160,
+      question: "WCAG SC 2.5.3 (Label in Name) requires that the accessible name of a control contains the visible label text. Why does this matter?",
+      options: [
+        "Speech input users say the visible label to activate the control, and speech recognition matches against the accessible name",
+        "It speeds up automated testing",
+        "It makes screen readers sound more natural",
+        "It is required for passing automated contrast checks"
+      ],
+      correct: 0,
+      explanation: "Speech recognition users (e.g., Dragon NaturallySpeaking, Voice Control) say the visible text of a control to activate it. If the accessible name differs, their command won't match. SC 2.5.3 prevents this mismatch.",
+      wrongExplanations: {
+        1: "Automated testing speed is unrelated.",
+        2: "Screen reader 'naturalness' is unrelated to Label in Name.",
+        3: "Contrast checks don't involve accessible names."
+      },
+      topicLinks: ['accessible-names-descriptions', 'wcag-operable'],
+      difficulty: 'hard',
+      tags: ['accessible-names', 'wcag-operable']
+    },
+    {
+      id: 1161,
+      question: "A designer labels a delete button visually as 'Delete' but sets aria-label='Remove item from cart'. What is the accessibility concern?",
+      options: [
+        "This violates SC 2.5.3 Label in Name because the visible text 'Delete' is not contained in the accessible name",
+        "Nothing — aria-label always wins, and this is fine",
+        "aria-label is not supported on buttons",
+        "It violates color contrast requirements"
+      ],
+      correct: 0,
+      explanation: "Since the accessible name ('Remove item from cart') does not contain the visible text ('Delete'), speech users who say 'click Delete' will fail to activate the control. The accessible name should at minimum contain the visible label.",
+      wrongExplanations: {
+        1: "aria-label winning is precisely what causes the mismatch.",
+        2: "aria-label is fully supported on buttons.",
+        3: "Contrast is a different requirement entirely."
+      },
+      topicLinks: ['accessible-names-descriptions', 'wcag-operable'],
+      difficulty: 'hard',
+      tags: ['accessible-names', 'wcag-operable']
+    },
+    {
+      id: 1162,
+      question: "Which sentence best describes how a <label> element associates with a form control?",
+      options: [
+        "Either by wrapping the control or by using a 'for' attribute whose value matches the control's id",
+        "By placing it immediately before the control in the DOM",
+        "By sharing the same CSS class",
+        "By being inside the same <fieldset>"
+      ],
+      correct: 0,
+      explanation: "A <label> associates with a control either implicitly (by wrapping it) or explicitly (via for=\"id\"). Both forms create a proper programmatic association that assistive technology recognizes.",
+      wrongExplanations: {
+        1: "DOM proximity alone does not create an association.",
+        2: "CSS classes have no semantic effect.",
+        3: "A fieldset groups controls and provides a group label via <legend>, but doesn't associate individual labels."
+      },
+      topicLinks: ['form-accessibility', 'accessible-names-descriptions'],
+      difficulty: 'easy',
+      tags: ['forms', 'accessible-names']
+    },
+    // =============================================
+    // WCAG-EM & CONFORMANCE (1163-1168)
+    // =============================================
+    {
+      id: 1163,
+      question: "Which of the following is NOT one of the five steps of the WCAG-EM evaluation methodology?",
+      options: [
+        "Rewrite inaccessible code",
+        "Define the evaluation scope",
+        "Explore the target website",
+        "Select a representative sample"
+      ],
+      correct: 0,
+      explanation: "WCAG-EM's five steps are: (1) define the scope, (2) explore the site, (3) select a representative sample, (4) audit the sample, and (5) report findings. Remediation (rewriting code) is not a step of the methodology itself.",
+      wrongExplanations: {
+        1: "Step 1 is defining the evaluation scope.",
+        2: "Step 2 is exploring the target site.",
+        3: "Step 3 is selecting a representative sample."
+      },
+      topicLinks: ['wcag-em', 'testing-fundamentals'],
+      difficulty: 'medium',
+      tags: ['wcag-em', 'testing']
+    },
+    {
+      id: 1164,
+      question: "In WCAG-EM, why is a 'representative sample' used instead of testing every page?",
+      options: [
+        "Because testing every page is usually infeasible, and a representative sample gives meaningful coverage of the site's unique templates and workflows",
+        "Because WCAG forbids testing more than 20 pages",
+        "Because sampled pages are more accessible than non-sampled pages",
+        "Because automated tools can only scan a fixed number of pages"
+      ],
+      correct: 0,
+      explanation: "For large sites, auditing every page is impractical. WCAG-EM guides evaluators to select both a structured sample (key templates, states, functionality) and a random sample so that the audit reflects the real site.",
+      wrongExplanations: {
+        1: "WCAG imposes no page count limit.",
+        2: "The goal is representativeness, not cherry-picking easy pages.",
+        3: "Automated tools can crawl many pages; sampling is about methodology, not tool limits."
+      },
+      topicLinks: ['wcag-em'],
+      difficulty: 'medium',
+      tags: ['wcag-em', 'testing']
+    },
+    {
+      id: 1165,
+      question: "Which of the following is a required component of a WCAG conformance claim?",
+      options: [
+        "The date of the claim, WCAG version and level, and the scope of content covered",
+        "A signed affidavit from an attorney",
+        "Approval from the W3C",
+        "A public audit by a third-party firm"
+      ],
+      correct: 0,
+      explanation: "A conformance claim must include (at minimum) the date, WCAG version, conformance level, and a precise description of the content that conforms. It may optionally list accessibility-supported technologies and exceptions.",
+      wrongExplanations: {
+        1: "Legal affidavits are not a WCAG requirement.",
+        2: "The W3C does not approve or certify individual claims.",
+        3: "Third-party audits are common but not required by WCAG itself."
+      },
+      topicLinks: ['wcag-em', 'wcag-overview'],
+      difficulty: 'hard',
+      tags: ['wcag-em', 'conformance']
+    },
+    {
+      id: 1166,
+      question: "A site claims 'WCAG 2.1 AA conformance,' but one form in the checkout flow is inaccessible. Which statement is most accurate?",
+      options: [
+        "The conformance claim is invalid because a single failing SC on in-scope content breaks conformance for that content",
+        "One broken form is acceptable since the rest of the site conforms",
+        "Only Level AAA requires full conformance",
+        "Conformance can be partial by percentage"
+      ],
+      correct: 0,
+      explanation: "WCAG conformance is all-or-nothing per level for the scoped content. A single failing SC within the conforming scope invalidates the claim for that scope.",
+      wrongExplanations: {
+        1: "Conformance is binary, not averaged.",
+        2: "All levels require full conformance to the criteria at and below that level.",
+        3: "Partial-by-percentage conformance is not a concept in WCAG."
+      },
+      topicLinks: ['wcag-em', 'wcag-overview'],
+      difficulty: 'hard',
+      tags: ['wcag-em', 'conformance']
+    },
+    {
+      id: 1167,
+      question: "What is the main purpose of Step 2 (Explore the Target Website) in WCAG-EM?",
+      options: [
+        "To understand the site's common pages, essential functionality, and technologies used before selecting a sample",
+        "To automatically scan every page for contrast errors",
+        "To run usability testing with people with disabilities",
+        "To generate the final accessibility report"
+      ],
+      correct: 0,
+      explanation: "Step 2 is a reconnaissance step: identify key workflows, representative page types, states, and the technologies in use. This understanding informs sample selection in Step 3.",
+      wrongExplanations: {
+        1: "Automated scanning may be part of the audit, but is not the purpose of the exploration step.",
+        2: "End-user testing is a complementary activity, not a WCAG-EM step.",
+        3: "Reporting happens in Step 5."
+      },
+      topicLinks: ['wcag-em'],
+      difficulty: 'medium',
+      tags: ['wcag-em']
+    },
+    {
+      id: 1168,
+      question: "What is 'accessibility supported' in the context of a WCAG conformance claim?",
+      options: [
+        "The technologies used (HTML, ARIA, etc.) must be supported by users' assistive technologies in the way the content relies on them",
+        "The website must be hosted on an accessible server",
+        "The site must provide a dedicated accessibility page",
+        "All users must have training in accessibility"
+      ],
+      correct: 0,
+      explanation: "WCAG requires that features relied upon for conformance be 'accessibility supported' — meaning real users can access them with their assistive technologies. Novel or niche tech may not qualify.",
+      wrongExplanations: {
+        1: "Hosting is unrelated.",
+        2: "An accessibility statement is recommended but not what this term means.",
+        3: "User training is outside the scope of conformance."
+      },
+      topicLinks: ['wcag-em', 'wcag-overview'],
+      difficulty: 'hard',
+      tags: ['wcag-em', 'conformance']
+    },
+    // =============================================
+    // ACT RULES & AUTOMATED TESTING (1169-1174)
+    // =============================================
+    {
+      id: 1169,
+      question: "What are ACT Rules?",
+      options: [
+        "Accessibility Conformance Testing rules — a W3C community format describing how to test specific accessibility requirements consistently",
+        "Legal rules that mandate accessibility in government websites",
+        "ARIA Compliance Tests defined by the WAI-ARIA spec",
+        "A proprietary rule set used by a specific testing vendor"
+      ],
+      correct: 0,
+      explanation: "ACT Rules are a W3C framework for writing testable accessibility rules. Each rule describes inputs, applicability, expectations, and outcomes so that different tools can implement them consistently and produce comparable results.",
+      wrongExplanations: {
+        1: "ACT is a technical framework, not a legal one.",
+        2: "ACT is independent of the ARIA spec.",
+        3: "ACT is an open W3C format, not vendor-proprietary."
+      },
+      topicLinks: ['act-rules', 'automated-testing-tools'],
+      difficulty: 'medium',
+      tags: ['act-rules', 'testing']
+    },
+    {
+      id: 1170,
+      question: "An automated tool passes a page for SC 1.1.1 (Non-text Content). What can you conclude?",
+      options: [
+        "Only that no automatically detectable failures were found — a manual review is still needed to judge whether alt text is accurate and meaningful",
+        "That the page fully conforms to SC 1.1.1",
+        "That the page contains no images",
+        "That WCAG 2.1 AA has been met for the entire site"
+      ],
+      correct: 0,
+      explanation: "Automated tools can verify the presence of alt attributes, but they can't judge whether the alt text is accurate, meaningful, or appropriate for the image's purpose. Manual review is required.",
+      wrongExplanations: {
+        1: "Passing automated checks is necessary but not sufficient for conformance.",
+        2: "It might contain images with alt text; the tool passed the check, not the absence of images.",
+        3: "A single passing SC says nothing about overall site conformance."
+      },
+      topicLinks: ['act-rules', 'automated-testing-tools', 'testing-fundamentals'],
+      difficulty: 'medium',
+      tags: ['testing', 'automated']
+    },
+    {
+      id: 1171,
+      question: "Roughly what fraction of WCAG issues can fully automated testing typically catch?",
+      options: [
+        "Estimates vary, but commonly cited figures are around 30–40 percent",
+        "Close to 100 percent",
+        "Less than 5 percent",
+        "Exactly 75 percent according to WCAG 2.1"
+      ],
+      correct: 0,
+      explanation: "Widely cited studies (e.g., from Deque) estimate that automated tools can detect around 30–40% of WCAG issues. The remainder requires manual and assistive-technology testing.",
+      wrongExplanations: {
+        1: "Full automation of WCAG testing is not possible.",
+        2: "Automated tools catch far more than 5%.",
+        3: "WCAG does not define a percentage."
+      },
+      topicLinks: ['automated-testing-tools', 'act-rules', 'testing-fundamentals'],
+      difficulty: 'medium',
+      tags: ['testing', 'automated']
+    },
+    {
+      id: 1172,
+      question: "Which type of issue is BEST suited for automated testing?",
+      options: [
+        "Detecting missing form labels, missing alt attributes, and insufficient color contrast on static text",
+        "Judging whether link text accurately describes its destination",
+        "Deciding if video captions are synchronized correctly",
+        "Evaluating whether an error message is clear and helpful to users"
+      ],
+      correct: 0,
+      explanation: "Automated tools excel at verifying deterministic DOM/CSS conditions: label associations, alt attribute presence, computed contrast ratios on known text/background pairs, and similar structural checks.",
+      wrongExplanations: {
+        1: "Judging meaning of link text requires human interpretation.",
+        2: "Caption timing accuracy needs a human reviewer or specialized testing.",
+        3: "Clarity and helpfulness of language are subjective judgments."
+      },
+      topicLinks: ['automated-testing-tools', 'act-rules'],
+      difficulty: 'easy',
+      tags: ['testing', 'automated']
+    },
+    {
+      id: 1173,
+      question: "Which of the following is a common guided manual testing tool that walks an evaluator through checks an automated tool cannot fully verify?",
+      options: [
+        "ARC Toolkit, WAVE's outline view, or axe DevTools' intelligent guided tests",
+        "ESLint",
+        "Webpack bundle analyzer",
+        "Lighthouse's performance audit"
+      ],
+      correct: 0,
+      explanation: "Tools like ARC Toolkit and axe DevTools include guided or 'intelligent' manual tests that help evaluators check items needing human judgment (e.g., heading hierarchy meaning, alt text accuracy).",
+      wrongExplanations: {
+        1: "ESLint is a JavaScript linter.",
+        2: "Webpack bundle analyzer inspects JavaScript bundle composition.",
+        3: "Lighthouse performance audits measure speed, not accessibility."
+      },
+      topicLinks: ['automated-testing-tools', 'testing-fundamentals'],
+      difficulty: 'medium',
+      tags: ['testing', 'tools']
+    },
+    {
+      id: 1174,
+      question: "An ACT Rule defines 'applicability' and 'expectations.' What do these terms mean?",
+      options: [
+        "Applicability identifies which elements the rule tests; expectations are the conditions those elements must meet to pass",
+        "Applicability is the test's legal jurisdiction; expectations are its legal consequences",
+        "Applicability is the browser support list; expectations are performance metrics",
+        "Applicability is the tool vendor; expectations are the price"
+      ],
+      correct: 0,
+      explanation: "ACT Rules use 'applicability' to define which elements the rule applies to and 'expectations' to define the pass/fail conditions. This structure makes rules deterministic and implementable across tools.",
+      wrongExplanations: {
+        1: "ACT is a technical framework, not a legal one.",
+        2: "Browser support and performance are separate concerns.",
+        3: "ACT has nothing to do with vendor pricing."
+      },
+      topicLinks: ['act-rules'],
+      difficulty: 'hard',
+      tags: ['act-rules']
+    },
+    // =============================================
+    // ACCESSIBILITY QA LIFECYCLE (1175-1178)
+    // =============================================
+    {
+      id: 1175,
+      question: "What does 'shift-left' mean in the context of accessibility QA?",
+      options: [
+        "Moving accessibility considerations earlier in the development lifecycle — into design and coding — rather than testing only at the end",
+        "Moving accessibility testing to the right side of the dev cycle to catch more bugs",
+        "Shifting UI elements to the left of the screen for RTL languages",
+        "Switching from manual to automated testing exclusively"
+      ],
+      correct: 0,
+      explanation: "Shift-left means addressing accessibility during requirements, design, and development, not just at QA. Early consideration reduces rework and catches issues when they are cheapest to fix.",
+      wrongExplanations: {
+        1: "Shift-left moves activity earlier (left), not later.",
+        2: "This is unrelated to RTL layout.",
+        3: "Shift-left doesn't imply abandoning manual testing."
+      },
+      topicLinks: ['accessibility-qa-lifecycle'],
+      difficulty: 'medium',
+      tags: ['qa', 'lifecycle']
+    },
+    {
+      id: 1176,
+      question: "In an agile team, where is accessibility BEST integrated?",
+      options: [
+        "Woven throughout: accessibility acceptance criteria in user stories, a11y checks in PR reviews, and automated a11y tests in CI",
+        "Done only once per quarter as a dedicated accessibility sprint",
+        "Left to a separate audit team after the product launches",
+        "Only considered during the design phase and never afterward"
+      ],
+      correct: 0,
+      explanation: "Sustainable accessibility in agile means embedding it into definition of done, story acceptance criteria, peer reviews, and CI pipelines — so every story is delivered accessible rather than retrofitted.",
+      wrongExplanations: {
+        1: "Quarterly sprints leave accessibility debt building between cycles.",
+        2: "Post-launch audits lead to costly rework.",
+        3: "Design is important, but implementation and testing also need accessibility focus."
+      },
+      topicLinks: ['accessibility-qa-lifecycle'],
+      difficulty: 'medium',
+      tags: ['qa', 'agile']
+    },
+    {
+      id: 1177,
+      question: "A CI pipeline runs axe-core against every pull request and fails the build on new violations. Which limitation should the team still be aware of?",
+      options: [
+        "Automated tests catch only a portion of WCAG issues; manual testing and assistive technology testing are still required",
+        "axe-core tests every WCAG success criterion completely",
+        "CI-based testing eliminates the need for design reviews",
+        "Failing builds on violations is a violation of WCAG"
+      ],
+      correct: 0,
+      explanation: "CI automation is valuable as a gate against regressions, but it cannot replace manual testing, AT testing, or design review. Teams must combine automation with human evaluation.",
+      wrongExplanations: {
+        1: "No automated tool covers every SC.",
+        2: "Design review remains critical for many SC.",
+        3: "WCAG does not regulate build processes."
+      },
+      topicLinks: ['accessibility-qa-lifecycle', 'automated-testing-tools'],
+      difficulty: 'medium',
+      tags: ['qa', 'ci', 'automation']
+    },
+    {
+      id: 1178,
+      question: "Why is it important to include accessibility criteria in the team's definition of done?",
+      options: [
+        "So work isn't declared complete until it meets accessibility standards, preventing accessibility debt from accumulating",
+        "Because WCAG explicitly requires a definition of done",
+        "To help the legal team build a defense in court",
+        "Because accessibility criteria speed up the release pipeline"
+      ],
+      correct: 0,
+      explanation: "A shared definition of done that includes accessibility ensures stories aren't called complete while inaccessible. This is one of the most effective organizational practices for sustaining accessibility.",
+      wrongExplanations: {
+        1: "WCAG does not prescribe development processes.",
+        2: "Legal defense is not the primary motivation.",
+        3: "Including a11y criteria adds rigor rather than raw speed."
+      },
+      topicLinks: ['accessibility-qa-lifecycle'],
+      difficulty: 'hard',
+      tags: ['qa', 'process']
+    },
+    // =============================================
+    // END-USER IMPACT TESTING (1179-1180)
+    // =============================================
+    {
+      id: 1179,
+      question: "What unique value does usability testing with people with disabilities provide over expert-based accessibility testing?",
+      options: [
+        "It reveals real-world barriers and workflow impacts that experts may miss, including cognitive load, AT-specific behavior, and the user's own strategies",
+        "It replaces the need for WCAG conformance",
+        "It is faster than automated testing",
+        "It removes any need for manual auditing"
+      ],
+      correct: 0,
+      explanation: "Usability testing with disabled users surfaces issues that conformance testing cannot — how real people with real AT setups actually experience the product, including frustration points and workarounds.",
+      wrongExplanations: {
+        1: "Usability testing complements, not replaces, conformance testing.",
+        2: "User testing is typically slower than automation.",
+        3: "Manual audits remain necessary."
+      },
+      topicLinks: ['disability-user-strategies', 'testing-fundamentals'],
+      difficulty: 'medium',
+      tags: ['user-testing']
+    },
+    {
+      id: 1180,
+      question: "Which is a best practice when conducting usability testing with people with disabilities?",
+      options: [
+        "Let participants use their own assistive technologies and personal settings — not a lab-standard setup",
+        "Provide unfamiliar AT so all participants have an identical baseline",
+        "Observe only passing behavior to keep the sessions short",
+        "Run tests only with users of a single disability type to simplify analysis"
+      ],
+      correct: 0,
+      explanation: "Participants should use their own AT and preferred settings, because that is how they will use the product in reality. Forcing unfamiliar tools introduces noise and does not reflect genuine user experience.",
+      wrongExplanations: {
+        1: "Unfamiliar AT produces artificial results.",
+        2: "Observing failures and struggles is where the most learning happens.",
+        3: "Testing with multiple disability groups yields richer insights."
+      },
+      topicLinks: ['disability-user-strategies'],
+      difficulty: 'hard',
+      tags: ['user-testing']
     }
   ]
 };

--- a/src/data/questions/was-domain3.js
+++ b/src/data/questions/was-domain3.js
@@ -1,0 +1,821 @@
+export const wasDomain3 = {
+  id: 'was-domain3',
+  courseId: 'was',
+  title: 'Remediating Accessibility Issues',
+  iconName: 'wrench',
+  color: 'bg-amber-600',
+  description: 'Prioritizing issues, recommending fixes, procurement, and organizational strategy.',
+  questions: [
+    // =============================================
+    // SEVERITY & PRIORITIZATION (1201-1214)
+    // =============================================
+    {
+      id: 1201,
+      question: "An accessibility audit reveals 50 issues. Which factor should MOST influence which issues are fixed first?",
+      options: [
+        "The WCAG Success Criterion number (lower numbers first)",
+        "The impact on users — whether the issue blocks, hinders, or merely inconveniences people with disabilities",
+        "The order in which the automated tool reported the issues",
+        "The visual prominence of the affected element on the page"
+      ],
+      correct: 1,
+      explanation: "User impact is the primary factor for prioritization. High-impact issues that completely block users with disabilities from completing tasks should be fixed before issues that merely cause inconvenience. This ensures limited remediation resources produce the greatest accessibility improvement.",
+      wrongExplanations: {
+        0: "WCAG SC numbering reflects document organization, not severity. SC 4.1.2 (Name, Role, Value) can be more critical than SC 1.1.1 (Non-text Content) in many contexts.",
+        2: "Automated tool report order is arbitrary and depends on DOM traversal order, not the severity or importance of the issues found.",
+        3: "Visual prominence matters for some users but is not the primary factor — a visually subtle form field that lacks a label can be a critical blocker for screen reader users."
+      },
+      topicLinks: ['remediation-prioritization'],
+      difficulty: 'easy',
+      tags: ['prioritization', 'remediation']
+    },
+    {
+      id: 1202,
+      question: "A website's checkout flow is completely inaccessible via keyboard, but a decorative image on the About page has poor alt text. Which should be fixed first and why?",
+      options: [
+        "The alt text, because SC 1.1.1 (Non-text Content) is Level A and keyboard access is Level A too, so order doesn't matter",
+        "The alt text, because image issues are easier for automated tools to verify",
+        "The checkout flow, because it blocks users from completing a critical task on a high-traffic page",
+        "Both should be fixed simultaneously since they are both Level A"
+      ],
+      correct: 2,
+      explanation: "The checkout flow should be prioritized because it blocks a critical user task — users cannot complete a purchase without keyboard access. Prioritization considers user impact (blocking vs. minor), the criticality of the affected task (checkout is essential), and page traffic. A decorative image's poor alt text is a minor issue by comparison.",
+      wrongExplanations: {
+        0: "While both may relate to Level A criteria, the conformance level alone does not determine remediation priority. User impact and task criticality are more important factors.",
+        1: "Ease of automated verification is a convenience factor for testers, not a valid reason to prioritize one issue over another. User impact should drive prioritization.",
+        3: "While fixing both is the ultimate goal, resource constraints require prioritization. The keyboard-blocking issue has far greater user impact and should come first."
+      },
+      topicLinks: ['remediation-prioritization', 'wcag-operable'],
+      difficulty: 'easy',
+      tags: ['prioritization', 'remediation', 'keyboard']
+    },
+    {
+      id: 1203,
+      question: "An accessibility issue exists in a shared navigation component used on every page of a 500-page website. Why should this issue be prioritized for remediation?",
+      options: [
+        "Because navigation components are visually prominent",
+        "Because fixing a template-level component resolves the issue across all 500 pages at once",
+        "Because navigation is always a Level A requirement",
+        "Because navigation issues are the easiest to test with automated tools"
+      ],
+      correct: 1,
+      explanation: "Template-level and component-library issues should be prioritized because fixing them once resolves the issue everywhere that component is used. A single fix in a shared navigation component eliminates the issue across all 500 pages, making it an extremely high-value remediation target.",
+      wrongExplanations: {
+        0: "Visual prominence alone does not determine remediation priority — a non-prominent form field with no label can be more critical.",
+        2: "Not all navigation requirements are Level A (e.g., SC 2.4.5 Multiple Ways is Level AA). And conformance level alone should not drive prioritization.",
+        3: "The ease of testing does not determine remediation priority. The key factor here is the multiplier effect of fixing a shared component."
+      },
+      topicLinks: ['remediation-prioritization'],
+      difficulty: 'easy',
+      tags: ['prioritization', 'remediation', 'templates']
+    },
+    {
+      id: 1204,
+      question: "When prioritizing accessibility issues for remediation, what does 'cost-benefit analysis' typically involve?",
+      options: [
+        "Calculating the exact dollar amount each issue costs the company in lost revenue",
+        "Weighing the effort required to fix an issue against the improvement in accessibility it delivers",
+        "Comparing the cost of an accessibility lawsuit against the cost of fixing the issue",
+        "Measuring the time to fix against the time remaining before a legal deadline"
+      ],
+      correct: 1,
+      explanation: "In accessibility remediation, cost-benefit analysis means evaluating the effort (development time, complexity, risk of regression) required to fix an issue against the accessibility improvement it delivers (user impact, number of users affected, severity of the barrier). Quick fixes with high user impact should be prioritized.",
+      wrongExplanations: {
+        0: "While lost revenue can be a factor, cost-benefit in accessibility prioritization focuses on remediation effort vs. user accessibility improvement, not precise revenue calculations.",
+        2: "Legal risk is one factor in prioritization, but cost-benefit analysis is broader — it weighs remediation effort against the accessibility improvement for users, not just legal exposure.",
+        3: "Legal deadlines are a constraint that affects scheduling, but cost-benefit analysis specifically weighs effort required against accessibility value delivered."
+      },
+      topicLinks: ['remediation-prioritization'],
+      difficulty: 'medium',
+      tags: ['prioritization', 'remediation', 'cost-benefit']
+    },
+    {
+      id: 1205,
+      question: "Which of the following is generally considered the HIGHEST severity accessibility issue?",
+      options: [
+        "A heading is marked up as <div class='heading'> instead of using a proper <h2> tag",
+        "A modal dialog does not return focus to the trigger button when closed",
+        "The entire checkout form cannot be accessed via keyboard at all",
+        "Color contrast on secondary body text is 4.2:1 instead of 4.5:1"
+      ],
+      correct: 2,
+      explanation: "A critical task (checkout) being completely inaccessible via keyboard is the highest severity issue because it entirely blocks keyboard users, switch device users, and screen reader users from completing an essential function. The other issues are real problems but allow workarounds or affect less critical interactions.",
+      wrongExplanations: {
+        0: "While improper heading markup affects screen reader navigation (SC 1.3.1), users can still access the content — it makes navigation harder but does not completely block access.",
+        1: "Focus management on dialog close is important (it can be disorienting), but users can still Tab to find their place. It does not completely block task completion.",
+        3: "Contrast just below the required ratio (4.2:1 vs. 4.5:1) is a compliance failure, but the text is still mostly readable. It does not block access entirely."
+      },
+      topicLinks: ['remediation-prioritization', 'wcag-operable'],
+      difficulty: 'medium',
+      tags: ['prioritization', 'severity', 'keyboard']
+    },
+    {
+      id: 1206,
+      question: "A remediation team has limited time. They can fix EITHER: (A) color contrast on 3 rarely visited pages, or (B) missing form labels on the login page. Which should they prioritize?",
+      options: [
+        "Option A — because color contrast affects more pages",
+        "Option B — because the login page is high-traffic and missing labels block form completion for AT users",
+        "Option A — because color contrast failures are easier to verify as fixed",
+        "Neither — they should wait until they can fix both at once"
+      ],
+      correct: 1,
+      explanation: "Missing form labels on the login page should be prioritized: the login page is a critical entry point with high traffic, and missing labels prevent assistive technology users from identifying and filling in form fields — a potential blocker. Color contrast on rarely visited pages, while important, affects fewer users and is less likely to completely block access.",
+      wrongExplanations: {
+        0: "The number of pages affected matters, but 3 rarely visited pages are less important than 1 high-traffic, essential-function page. User impact and task criticality outweigh page count.",
+        2: "Ease of verification is a testing convenience, not a valid prioritization factor. User impact should drive the decision.",
+        3: "Waiting to fix both when one issue is significantly more impactful than the other wastes time and leaves a critical barrier in place."
+      },
+      topicLinks: ['remediation-prioritization', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['prioritization', 'remediation', 'forms']
+    },
+    {
+      id: 1207,
+      question: "According to WCAG, what must be true for a page to conform to Level AA?",
+      options: [
+        "All Level AA Success Criteria are met, but Level A failures are acceptable",
+        "All Level A and Level AA Success Criteria are met on that page",
+        "At least 80% of Level A and AA Success Criteria are met",
+        "All Level A, AA, and AAA Success Criteria are met"
+      ],
+      correct: 1,
+      explanation: "WCAG conformance is cumulative: to conform to Level AA, a page must satisfy ALL Level A Success Criteria AND all Level AA Success Criteria. If even one A or AA criterion fails, the page does not conform to Level AA. There is no partial conformance — it is pass/fail.",
+      wrongExplanations: {
+        0: "Conformance levels are cumulative. Level AA includes all Level A criteria. You cannot claim AA conformance while failing Level A criteria.",
+        2: "WCAG conformance is binary pass/fail — there is no percentage threshold. Every applicable SC must pass for conformance to be claimed.",
+        3: "Level AAA includes A and AA, but Level AA conformance does not require meeting AAA criteria. WCAG recommends against requiring AAA conformance for entire sites."
+      },
+      topicLinks: ['wcag-overview', 'remediation-prioritization'],
+      difficulty: 'easy',
+      tags: ['wcag-conformance', 'remediation']
+    },
+    {
+      id: 1208,
+      question: "Which factor from EN 301 549 can help determine the user-group impact of a specific accessibility issue?",
+      options: [
+        "Clause 4 Functional Performance Statements and Annex B, which map requirements to user needs",
+        "Clause 12, which addresses documentation and support services",
+        "The VPAT conformance levels (Supports, Partially Supports, Does Not Support)",
+        "The WCAG-EM Report Tool's scoring algorithm"
+      ],
+      correct: 0,
+      explanation: "EN 301 549 Clause 4 defines Functional Performance Statements (user needs like 'Usage without vision', 'Usage with limited cognition') and Annex B maps these to specific technical requirements. This mapping helps determine which user groups are affected by a particular accessibility issue, informing remediation prioritization.",
+      wrongExplanations: {
+        1: "Clause 12 covers documentation and support services. While important for accessibility, it does not map accessibility requirements to specific user needs.",
+        2: "VPAT conformance levels are reporting categories for vendor self-assessment, not tools for analyzing user-group impact of specific issues.",
+        3: "The WCAG-EM Report Tool helps structure evaluation reports but does not include a scoring algorithm for user-group impact analysis."
+      },
+      topicLinks: ['remediation-prioritization', 'en-301-549'],
+      difficulty: 'hard',
+      tags: ['prioritization', 'en-301-549', 'user-impact']
+    },
+    {
+      id: 1209,
+      question: "A website fails SC 2.1.2 No Keyboard Trap on one page. Why is this considered particularly severe even if the page has low traffic?",
+      options: [
+        "Because SC 2.1.2 is a Level A criterion and all Level A criteria are critical",
+        "Because a keyboard trap can completely prevent the user from accessing the rest of the page or even the browser",
+        "Because keyboard traps also cause seizures in users with photosensitive conditions",
+        "Because SC 2.1.2 is one of WCAG's non-interference criteria, meaning it must be met even for non-conforming content"
+      ],
+      correct: 3,
+      explanation: "SC 2.1.2 No Keyboard Trap is one of WCAG's four non-interference conformance requirements (along with 1.4.2 Audio Control, 2.2.2 Pause/Stop/Hide, and 2.3.1 Three Flashes). These must be met even for content that uses technologies in non-conforming ways, because failure blocks access to the entire page. This special status makes keyboard trap violations particularly severe.",
+      wrongExplanations: {
+        0: "While Level A criteria are important, not all Level A issues are equally severe. The specific severity here comes from the non-interference status, not just the conformance level.",
+        1: "This is partially correct — keyboard traps do block users — but the question asks why it is particularly severe. The non-interference status is the distinguishing factor that elevates its severity.",
+        2: "Keyboard traps do not cause seizures. Seizure risks are addressed by SC 2.3.1 (Three Flashes), which is a separate concern from keyboard traps."
+      },
+      topicLinks: ['remediation-prioritization', 'wcag-operable', 'wcag-overview'],
+      difficulty: 'hard',
+      tags: ['prioritization', 'keyboard', 'conformance', 'non-interference']
+    },
+    {
+      id: 1210,
+      question: "When reporting remediation priorities to stakeholders, which communication approach is MOST effective?",
+      options: [
+        "List every WCAG Success Criterion number that fails, sorted numerically",
+        "Describe each issue in terms of user impact, affected user groups, and the recommended fix with its relative effort",
+        "Show the automated scan score as a percentage and target 100%",
+        "Only report Level A failures since those are the most severe"
+      ],
+      correct: 1,
+      explanation: "Effective communication translates technical findings into actionable terms stakeholders can understand: what the issue means for real users, who is affected, what the fix involves, and how much effort it requires. This enables informed decision-making about resource allocation and prioritization.",
+      wrongExplanations: {
+        0: "Listing SC numbers without context is not meaningful to most stakeholders. They need to understand the user impact and effort involved, not just the technical reference codes.",
+        2: "Automated scan scores are misleading — tools only catch 30-50% of issues, so a high automated score does not mean good accessibility. Using it as the primary metric gives false confidence.",
+        3: "Only reporting Level A failures ignores Level AA issues that may be legally required (most laws reference Level AA) and may significantly impact users."
+      },
+      topicLinks: ['remediation-prioritization', 'remediation-strategies'],
+      difficulty: 'medium',
+      tags: ['communication', 'prioritization', 'stakeholders']
+    },
+    {
+      id: 1211,
+      question: "An audit finds that the same color contrast failure appears on every page because it is defined in the global CSS theme. What type of remediation issue is this?",
+      options: [
+        "A content-level issue requiring page-by-page fixes",
+        "A template or design-system issue where a single fix resolves it site-wide",
+        "A third-party component issue that cannot be fixed",
+        "A best-practice issue that is not a WCAG failure"
+      ],
+      correct: 1,
+      explanation: "When an accessibility issue originates in shared CSS, templates, or design systems, it is a template-level issue. Fixing the color values in the global CSS theme resolves the contrast failure across every page at once. These issues are high-priority remediation targets because of their site-wide multiplier effect.",
+      wrongExplanations: {
+        0: "Since the issue is in the global CSS, page-by-page fixes would be redundant and wasteful. The fix belongs in the shared stylesheet.",
+        2: "A global CSS theme is typically under the organization's control, not a third-party component. It can and should be fixed.",
+        3: "Insufficient color contrast (failing SC 1.4.3 or 1.4.6) is a WCAG conformance failure, not merely a best practice."
+      },
+      topicLinks: ['remediation-prioritization', 'color-contrast'],
+      difficulty: 'easy',
+      tags: ['prioritization', 'templates', 'color-contrast']
+    },
+    {
+      id: 1212,
+      question: "Which of the following remediation approaches reflects a 'shift-left' strategy?",
+      options: [
+        "Running an accessibility audit after the website launches and fixing issues in patches",
+        "Including accessibility requirements in user stories, testing during development, and catching issues before they reach production",
+        "Hiring an external consultant to audit the website annually",
+        "Adding ARIA attributes to fix issues found during a pre-launch QA pass"
+      ],
+      correct: 1,
+      explanation: "Shift-left means moving accessibility consideration earlier (to the left) in the development timeline — from post-launch remediation to requirements, design, and development phases. Including accessibility in user stories and testing during development catches issues when they are cheapest and easiest to fix.",
+      wrongExplanations: {
+        0: "Fixing issues after launch is reactive remediation — the opposite of shift-left. Issues found this late are more expensive and disruptive to fix.",
+        2: "Annual external audits are valuable but are point-in-time assessments. Shift-left is about continuous, integrated accessibility throughout development, not periodic checks.",
+        3: "Adding ARIA in a pre-launch QA pass is better than post-launch, but it still means accessibility was not considered during design and development — it is a late-stage patch, not true shift-left."
+      },
+      topicLinks: ['accessibility-qa-lifecycle', 'remediation-prioritization'],
+      difficulty: 'medium',
+      tags: ['shift-left', 'lifecycle', 'remediation']
+    },
+    {
+      id: 1213,
+      question: "An organization's website must comply with a law requiring WCAG 2.2 Level AA. Which issues carry the highest legal risk?",
+      options: [
+        "Level AAA failures, since those represent the highest standard",
+        "Best-practice recommendations from automated scanning tools",
+        "Level A and Level AA failures on pages covered by the legal requirement",
+        "Issues found only during usability testing with people with disabilities"
+      ],
+      correct: 2,
+      explanation: "If the law requires WCAG 2.2 Level AA conformance, then any failure of a Level A or Level AA Success Criterion on in-scope pages represents non-compliance and carries legal risk. Level AAA is not typically required by law, and best-practice issues that do not fail specific SC are not conformance failures.",
+      wrongExplanations: {
+        0: "Level AAA is not typically required by law and WCAG itself recommends against requiring AAA conformance for entire sites. Legal risk primarily comes from failing the required level (AA).",
+        1: "Automated tool best-practice recommendations may not map to specific WCAG SC failures. Legal risk comes from failing the normative requirements, not informative best practices.",
+        3: "Usability issues found only during user testing, without corresponding WCAG SC failures, may not constitute legal non-compliance — though they represent real accessibility barriers."
+      },
+      topicLinks: ['remediation-prioritization', 'wcag-overview'],
+      difficulty: 'medium',
+      tags: ['legal-risk', 'conformance', 'remediation']
+    },
+    {
+      id: 1214,
+      question: "What is a key risk of relying solely on automated accessibility scan scores to measure remediation progress?",
+      options: [
+        "Automated tools are too expensive for regular use",
+        "Automated tools can only test static HTML, not dynamic content",
+        "Automated tools catch only 30-50% of accessibility issues, so a perfect score can still hide many barriers",
+        "Automated tools only test against WCAG 2.0, not WCAG 2.2"
+      ],
+      correct: 2,
+      explanation: "Automated accessibility tools can detect roughly 30-50% of WCAG issues (primarily formal, code-level checks like missing alt attributes or missing form labels). They cannot evaluate content quality, keyboard interaction patterns, or the meaningfulness of alternatives. A perfect automated score gives false confidence — significant barriers may remain undetected.",
+      wrongExplanations: {
+        0: "Many automated tools are free or low-cost (axe, WAVE, Lighthouse). Cost is not the primary limitation.",
+        1: "Modern automated tools can interact with dynamic content and JavaScript-rendered pages. The limitation is the types of issues they can detect, not the types of content they can process.",
+        3: "Modern automated tools support current WCAG versions including 2.1 and 2.2 criteria. The limitation is the depth of testing, not the standard version."
+      },
+      topicLinks: ['remediation-prioritization', 'automated-testing-tools'],
+      difficulty: 'medium',
+      tags: ['automated-testing', 'remediation', 'limitations']
+    },
+
+    // =============================================
+    // REMEDIATION STRATEGIES (1215-1228)
+    // =============================================
+    {
+      id: 1215,
+      question: "What is the key difference between a WCAG conformance failure and an accessibility best practice recommendation?",
+      options: [
+        "Failures are found by automated tools; best practices are found by manual testing",
+        "A failure clearly violates a specific WCAG Success Criterion; a best practice improves usability but does not fail a specific SC",
+        "Failures apply to Level A only; best practices apply to Level AA and AAA",
+        "Failures must be fixed immediately; best practices can be ignored entirely"
+      ],
+      correct: 1,
+      explanation: "A conformance failure is a specific violation of a normative WCAG Success Criterion — it must be fixed to achieve conformance. A best practice improves accessibility and usability but does not violate a specific SC. Auditors must clearly distinguish between the two when reporting findings, as they have different implications for conformance claims and legal compliance.",
+      wrongExplanations: {
+        0: "Both failures and best practices can be found through automated or manual testing. The distinction is whether a specific SC is violated, not how the issue was discovered.",
+        2: "Failures can occur at any conformance level (A, AA, or AAA). Best practices are not tied to specific levels — they are recommendations that go beyond the normative requirements.",
+        3: "While failures have higher legal urgency, best practices should not be ignored — they represent real accessibility improvements. The distinction is about conformance status, not importance."
+      },
+      topicLinks: ['remediation-strategies', 'wcag-overview'],
+      difficulty: 'easy',
+      tags: ['remediation', 'conformance', 'best-practices']
+    },
+    {
+      id: 1216,
+      question: "A complex data table is displayed using nested <div> elements with CSS Grid for layout. Screen readers cannot identify headers or navigate cells. What is the BEST remediation approach?",
+      options: [
+        "Add aria-label to each <div> cell describing its content",
+        "Replace the <div> structure with semantic <table>, <th>, <tr>, <td> elements",
+        "Add role='table', role='row', and role='cell' to the existing <div> elements",
+        "Add a text description above the table explaining its structure"
+      ],
+      correct: 1,
+      explanation: "The best remediation is to use semantic HTML table elements (<table>, <th>, <tr>, <td>) which provide built-in support for header associations, row/column navigation, and screen reader table navigation commands. This follows the first rule of ARIA: use native HTML with built-in semantics instead of recreating functionality with ARIA.",
+      wrongExplanations: {
+        0: "Adding aria-label to each cell does not create the table semantics needed for header/cell associations and screen reader table navigation. It would require labeling every single cell and would not support structural navigation.",
+        2: "While adding ARIA table roles can work as a patch, it requires significantly more code (role='table', role='rowgroup', role='row', role='columnheader', role='cell', plus aria-colindex/aria-rowindex) and is less reliable than native HTML tables. Semantic HTML is preferred.",
+        3: "A text description supplements but does not replace programmatic table structure. Screen reader users need to navigate the table cells and hear associated headers, which requires semantic markup."
+      },
+      topicLinks: ['remediation-strategies', 'semantic-html'],
+      difficulty: 'medium',
+      tags: ['remediation', 'semantic-html', 'tables']
+    },
+    {
+      id: 1217,
+      question: "A form has no <label> elements — form fields are identified only by placeholder text. What is the MOST robust fix?",
+      options: [
+        "Add aria-label to each input matching the placeholder text",
+        "Add <label> elements visually hidden with CSS, associated via for/id",
+        "Add <label> elements visible to all users, associated via for/id",
+        "Change the placeholder color to meet contrast requirements"
+      ],
+      correct: 2,
+      explanation: "Visible <label> elements associated via for/id are the most robust fix because they: (1) provide a persistent visible label (placeholders disappear on input), (2) are natively associated with the form control for assistive technologies, (3) increase the clickable area of the form control, and (4) benefit all users including those with cognitive disabilities.",
+      wrongExplanations: {
+        0: "aria-label provides a programmatic name but not a visible label. Sighted users still lose their reference when they start typing and the placeholder disappears. This fails to address the usability issue.",
+        1: "Visually hidden labels fix the screen reader issue but not the usability problem — sighted users still lose their label reference when the placeholder disappears on input. Visible labels are better for all users.",
+        3: "Improving placeholder contrast does not fix the core problem: placeholders disappear when users start typing, leaving no visible label. Contrast alone does not make placeholders an adequate label substitute."
+      },
+      topicLinks: ['remediation-strategies', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['remediation', 'forms', 'labels']
+    },
+    {
+      id: 1218,
+      question: "When should ARIA be used as a remediation approach rather than refactoring to semantic HTML?",
+      options: [
+        "Always — ARIA is more powerful and flexible than native HTML",
+        "When the codebase makes full refactoring impractical as an immediate fix, ARIA can serve as a bridge while planning a proper semantic rewrite",
+        "Only for decorative elements that need to be hidden from screen readers",
+        "When the website needs to support older browsers that do not understand HTML5 semantic elements"
+      ],
+      correct: 1,
+      explanation: "ARIA is appropriate as a remediation bridge when full semantic refactoring is impractical in the short term — for example, when the code is complex, heavily coupled, or the timeline is tight. ARIA can add missing semantics to existing elements while a longer-term plan for semantic HTML refactoring is developed. However, native HTML should always be the goal.",
+      wrongExplanations: {
+        0: "ARIA is not more powerful — native HTML provides keyboard behavior, state management, and cross-platform compatibility that ARIA does not. The first rule of ARIA is to use native HTML when possible.",
+        2: "Hiding decorative elements (aria-hidden='true') is one use of ARIA, but the question asks about remediation strategy. ARIA's role in remediation is broader — adding missing names, roles, and states to elements.",
+        3: "All modern browsers support HTML5 semantic elements. Older browser support is not a valid reason to prefer ARIA over semantic HTML in current development."
+      },
+      topicLinks: ['remediation-strategies', 'aria-overview', 'standard-vs-custom-controls'],
+      difficulty: 'medium',
+      tags: ['remediation', 'aria', 'semantic-html']
+    },
+    {
+      id: 1219,
+      question: "A website uses color alone to indicate required form fields (red border). What is the BEST remediation?",
+      options: [
+        "Increase the red border contrast to 4.5:1",
+        "Add an asterisk (*) with a visible legend explaining its meaning, plus the 'required' attribute on the input",
+        "Add a tooltip that says 'Required' on hover",
+        "Change the red border to a thicker border"
+      ],
+      correct: 1,
+      explanation: "The best fix addresses both color independence (SC 1.4.1 Use of Color) and programmatic identification. An asterisk with a legend provides a non-color visual indicator, and the 'required' HTML attribute makes the required state programmatically determinable for assistive technologies (SC 1.3.1 Info and Relationships, SC 3.3.2 Labels or Instructions).",
+      wrongExplanations: {
+        0: "Increasing contrast of the red border improves visibility but still relies on color alone to convey the 'required' status. Users who cannot perceive color need a non-color indicator.",
+        2: "Tooltips on hover are not accessible to keyboard users, touch users, or screen reader users in browse mode. They are not a reliable way to convey important information.",
+        3: "A thicker border is still a visual-only distinction that does not convey meaning programmatically. Screen reader users would not know the field is required."
+      },
+      topicLinks: ['remediation-strategies', 'form-accessibility', 'color-contrast'],
+      difficulty: 'medium',
+      tags: ['remediation', 'forms', 'color', 'use-of-color']
+    },
+    {
+      id: 1220,
+      question: "An auditor finds that a custom dropdown menu is missing keyboard support, has no ARIA roles, and does not expose its expanded/collapsed state. The team asks: fix or redesign? What factors guide this decision?",
+      options: [
+        "Always fix — redesign is too expensive",
+        "Always redesign — fixing custom components is not worth the effort",
+        "Evaluate the code complexity, scope of defects, available resources, and whether fixing would be more fragile and costly than a clean rewrite using semantic HTML and ARIA best practices",
+        "The decision depends solely on whether the component is open source or proprietary"
+      ],
+      correct: 2,
+      explanation: "The fix-vs-redesign decision requires evaluating multiple factors: how complex and maintainable the current code is, how many separate issues exist, whether patches would be fragile, available time and budget, and whether a rewrite using semantic HTML and APG patterns would produce a more robust, maintainable result. Neither always-fix nor always-redesign is correct — it depends on context.",
+      wrongExplanations: {
+        0: "'Always fix' ignores situations where the existing code is so poorly structured that patches would be fragile, incomplete, and harder to maintain than a clean rewrite.",
+        1: "'Always redesign' ignores situations where targeted fixes are practical and cost-effective, especially under time pressure or for components with limited issues.",
+        3: "Whether code is open source or proprietary may affect licensing, but the fix-vs-redesign decision is driven by code quality, defect scope, and resource availability."
+      },
+      topicLinks: ['remediation-strategies', 'standard-vs-custom-controls'],
+      difficulty: 'hard',
+      tags: ['remediation', 'fix-vs-redesign', 'custom-controls']
+    },
+    {
+      id: 1221,
+      question: "An image has alt='image.jpg'. What is the correct remediation?",
+      options: [
+        "Remove the alt attribute entirely so the screen reader skips the image",
+        "If the image is informative, replace with a meaningful description; if decorative, use alt='' (empty string)",
+        "Replace with alt='image' to shorten the text",
+        "Add role='presentation' to keep the current alt text but hide the image's role"
+      ],
+      correct: 1,
+      explanation: "The correct fix depends on the image's purpose. If informative, the alt text should describe the image's content or function meaningfully. If decorative, alt='' (empty string) tells assistive technologies to skip it. 'image.jpg' is a filename that provides no useful information to users.",
+      wrongExplanations: {
+        0: "Removing the alt attribute entirely causes most screen readers to announce the image's filename or URL instead — making the experience worse, not better.",
+        2: "Replacing 'image.jpg' with 'image' is still meaningless and does not describe the image's content or purpose.",
+        3: "Adding role='presentation' while keeping a meaningless alt text is contradictory. If the image is decorative, use alt=''. If informative, provide a meaningful description."
+      },
+      topicLinks: ['remediation-strategies', 'wcag-perceivable'],
+      difficulty: 'easy',
+      tags: ['remediation', 'images', 'alt-text']
+    },
+    {
+      id: 1222,
+      question: "A custom tab widget uses <div> elements with click handlers. Keyboard users cannot navigate between tabs. What is the recommended keyboard interaction pattern to implement?",
+      options: [
+        "Each tab should be focusable with Tab, and activated with Enter",
+        "Arrow keys move between tabs within the tablist; Tab moves focus out of the tablist to the tab panel content",
+        "All tabs should be in a single focusable group activated by number keys",
+        "Tabs should be navigated using Page Up and Page Down keys"
+      ],
+      correct: 1,
+      explanation: "The ARIA Authoring Practices Guide (APG) tab pattern specifies: Tab key moves focus into the tablist (to the active tab) and out to the tab panel. Arrow keys (Left/Right for horizontal, Up/Down for vertical) move between tabs within the tablist. This follows the composite widget pattern where Tab enters/exits the widget and arrows navigate within it.",
+      wrongExplanations: {
+        0: "Making each tab individually tabbable would require many Tab presses to get through the tabs and reach the content. The APG pattern uses arrows within the tablist and Tab to enter/exit.",
+        2: "Number keys are not part of the standard tab widget keyboard pattern. The APG defines arrow keys for tab navigation.",
+        3: "Page Up/Down are not part of the standard tab widget pattern. They may be used in some widgets (like date pickers) but not for tab navigation."
+      },
+      topicLinks: ['remediation-strategies', 'aria-widget-patterns', 'standard-vs-custom-controls'],
+      difficulty: 'hard',
+      tags: ['remediation', 'keyboard', 'tabs', 'apg']
+    },
+    {
+      id: 1223,
+      question: "A page heading structure goes: <h1>, <h3>, <h2>, <h4>. What is the correct remediation?",
+      options: [
+        "Add CSS to make them all look different sizes",
+        "Restructure to a logical hierarchy: h1 → h2 → h3 → h4, reflecting the content outline",
+        "Replace all headings with <div> elements and use aria-level to set heading levels",
+        "Only fix the heading levels that automated tools flag as errors"
+      ],
+      correct: 1,
+      explanation: "Headings should form a logical hierarchy that reflects the content structure (SC 1.3.1 Info and Relationships). The fix is to assign heading levels based on content relationships: the page title is h1, major sections are h2, subsections are h3, and so on. Visual styling is controlled separately through CSS.",
+      wrongExplanations: {
+        0: "CSS styling changes visual presentation but does not fix the programmatic heading structure that assistive technologies use for navigation.",
+        2: "Using <div> with aria-level removes native heading semantics and is less robust than native heading elements. The first rule of ARIA: use native HTML when possible.",
+        3: "Automated tools may not catch all heading hierarchy issues (e.g., they may not flag skipped levels in all contexts). The entire heading structure should reflect the content outline."
+      },
+      topicLinks: ['remediation-strategies', 'semantic-html'],
+      difficulty: 'easy',
+      tags: ['remediation', 'headings', 'semantic-html']
+    },
+    {
+      id: 1224,
+      question: "A website's body text has a contrast ratio of 3.8:1 against its background. What is the minimum required ratio and what should the remediation target?",
+      options: [
+        "Minimum is 3:1; the current contrast passes — no fix needed",
+        "Minimum is 4.5:1 for normal text (SC 1.4.3, Level AA); darken the text or lighten the background to meet at least 4.5:1",
+        "Minimum is 7:1 (SC 1.4.6, Level AAA); a major color scheme change is required",
+        "Contrast requirements only apply to images of text, not real text"
+      ],
+      correct: 1,
+      explanation: "SC 1.4.3 Contrast (Minimum) at Level AA requires a 4.5:1 ratio for normal-size text and 3:1 for large text (18pt or 14pt bold). At 3.8:1, the body text fails the 4.5:1 requirement. The fix is to adjust foreground or background colors to achieve at least 4.5:1.",
+      wrongExplanations: {
+        0: "The 3:1 ratio applies to large text (18pt or 14pt bold) and non-text UI components (SC 1.4.11). Normal body text requires 4.5:1 at Level AA.",
+        2: "The 7:1 ratio is SC 1.4.6 Enhanced Contrast at Level AAA, which is an aspirational target. The legal requirement for most purposes is Level AA (4.5:1).",
+        3: "SC 1.4.3 applies to all text, not just images of text. In fact, real text is preferred over images of text specifically because users can adjust its presentation."
+      },
+      topicLinks: ['remediation-strategies', 'color-contrast'],
+      difficulty: 'medium',
+      tags: ['remediation', 'color-contrast', 'wcag-perceivable']
+    },
+    {
+      id: 1225,
+      question: "An auditor reports: 'SC 1.3.1 Failure: Navigation list is not marked up as a list.' The developer asks why, since the navigation looks correct visually. How should the auditor explain?",
+      options: [
+        "Visual appearance is what matters for accessibility — if it looks like a list, it functions as one",
+        "Screen readers use the semantic markup to convey structure — a visually styled set of links without list markup does not convey the grouping, item count, or position to assistive technology users",
+        "All navigations must use <ol> ordered lists because the order of links matters",
+        "The issue is that <nav> is missing, not the list markup"
+      ],
+      correct: 1,
+      explanation: "SC 1.3.1 requires that information conveyed through visual presentation is also available programmatically. When a navigation appears as a list visually, it should be marked up as a list (<ul>/<ol> with <li>) so screen readers can announce the number of items, the user's position in the list, and the grouping relationship. Without this markup, the structure is lost for AT users.",
+      wrongExplanations: {
+        0: "Visual appearance is only one aspect of accessibility. Programmatic structure (semantic markup) is equally important for users who cannot see the visual layout and rely on assistive technologies.",
+        2: "Either <ul> (unordered) or <ol> (ordered) list is acceptable depending on whether order is meaningful. Most navigation uses <ul> since the specific order of links is not typically significant.",
+        3: "While <nav> is important for landmark navigation, the auditor specifically cited list markup. Both <nav> and proper list structure contribute to accessibility, but they address different aspects."
+      },
+      topicLinks: ['remediation-strategies', 'semantic-html', 'wcag-perceivable'],
+      difficulty: 'medium',
+      tags: ['remediation', 'semantic-html', 'info-relationships']
+    },
+    {
+      id: 1226,
+      question: "A website passes all automated accessibility checks but screen reader users report they cannot use the site's date picker widget. Why might this happen?",
+      options: [
+        "Automated tools cannot test custom widgets — they can only check static HTML properties like alt text and color contrast",
+        "The screen reader software must be outdated",
+        "Automated tools verify formal code properties but cannot test keyboard interaction patterns, focus management, or whether ARIA roles and states are correctly implemented in dynamic widgets",
+        "The date picker is a third-party component, and automated tools skip third-party code"
+      ],
+      correct: 2,
+      explanation: "Automated tools excel at checking code-level properties (missing alt, color contrast, missing labels, valid ARIA attributes) but cannot verify behavioral aspects: whether keyboard navigation works correctly, whether focus moves as expected, whether ARIA states update dynamically, or whether the widget follows APG interaction patterns. These require manual and AT testing.",
+      wrongExplanations: {
+        0: "This overstates the limitation. Automated tools can check some properties of custom widgets (valid ARIA roles, required attributes, accessible names). They just cannot test the interactive behavior.",
+        1: "Screen reader compatibility issues are real, but blaming outdated software without investigation is not appropriate. The issue is more likely that the widget was not built to ARIA best practices.",
+        3: "Automated tools scan all rendered DOM content regardless of whether it comes from first-party or third-party code. They do not distinguish code origin."
+      },
+      topicLinks: ['remediation-strategies', 'automated-testing-tools', 'aria-widget-patterns'],
+      difficulty: 'hard',
+      tags: ['remediation', 'automated-testing', 'custom-controls', 'limitations']
+    },
+    {
+      id: 1227,
+      question: "A developer adds tabindex='5' to a button to make it the first item to receive focus on the page. What is the problem and the correct fix?",
+      options: [
+        "tabindex='5' is too low — use tabindex='100' to ensure it is first",
+        "Positive tabindex values create unpredictable focus order; instead, move the button earlier in the DOM source order",
+        "tabindex values must be negative to receive focus",
+        "tabindex only works on <a> and <input> elements, not <button>"
+      ],
+      correct: 1,
+      explanation: "Positive tabindex values (>0) create a parallel focus order that takes priority over DOM order, making the focus sequence unpredictable and difficult to maintain. The correct approach is to place the element in the appropriate position in the DOM source order, ensuring focus order follows the visual and logical reading order naturally.",
+      wrongExplanations: {
+        0: "Any positive tabindex — whether 5 or 100 — creates the same problem: an unpredictable focus order that is separate from the DOM order and extremely difficult to manage as the page evolves.",
+        2: "Negative tabindex (tabindex='-1') makes an element programmatically focusable but removes it from the Tab order. tabindex='0' places an element in the natural Tab order. Both are valid for different purposes.",
+        3: "tabindex works on any HTML element. Native interactive elements (<button>, <a>, <input>) already have tabindex='0' implicitly."
+      },
+      topicLinks: ['remediation-strategies', 'focus-indicators', 'wcag-operable'],
+      difficulty: 'medium',
+      tags: ['remediation', 'focus-order', 'tabindex']
+    },
+    {
+      id: 1228,
+      question: "A page has auto-playing video with sound. Which WCAG non-interference requirement does this violate, and what is the correct fix?",
+      options: [
+        "SC 1.4.2 Audio Control (Level A) — provide a mechanism to pause, stop, or control the volume within the first 3 seconds, or do not auto-play audio",
+        "SC 2.3.1 Three Flashes (Level A) — remove any flashing content from the video",
+        "SC 1.2.1 Audio-only and Video-only (Level A) — provide a transcript",
+        "SC 2.2.2 Pause, Stop, Hide (Level A) — allow the user to pause the video"
+      ],
+      correct: 0,
+      explanation: "SC 1.4.2 Audio Control (Level A) is a non-interference requirement: if audio plays automatically for more than 3 seconds, there must be a mechanism to pause/stop it or control the volume independently of the system volume. This is critical because auto-playing audio interferes with screen reader speech output, making the page unusable.",
+      wrongExplanations: {
+        1: "SC 2.3.1 addresses seizure-inducing flashing content, not auto-playing audio. While the video may also need to meet SC 2.3.1, the auto-playing sound issue is specifically SC 1.4.2.",
+        2: "SC 1.2.1 requires alternatives for audio-only and video-only prerecorded content. It addresses the availability of content alternatives, not auto-playing behavior.",
+        3: "SC 2.2.2 applies to moving, blinking, or scrolling content and auto-updating information. While video is moving content, the specific issue of auto-playing audio is addressed by SC 1.4.2."
+      },
+      topicLinks: ['remediation-strategies', 'wcag-perceivable', 'wcag-overview'],
+      difficulty: 'hard',
+      tags: ['remediation', 'audio', 'non-interference', 'wcag-perceivable']
+    },
+
+    // =============================================
+    // PROCUREMENT & ORGANIZATIONAL (1229-1240)
+    // =============================================
+    {
+      id: 1229,
+      question: "What is the relationship between a VPAT and an ACR?",
+      options: [
+        "They are completely different documents for different purposes",
+        "The VPAT is the blank template; the ACR (Accessibility Conformance Report) is the completed document that evaluates a specific product",
+        "The ACR is the blank template; the VPAT is the completed evaluation",
+        "VPAT is the US version and ACR is the European version of the same document"
+      ],
+      correct: 1,
+      explanation: "VPAT (Voluntary Product Accessibility Template) is the standardized template created by the Information Technology Industry Council (ITI). When a vendor fills out the VPAT for a specific product, the completed document is called an ACR (Accessibility Conformance Report). In practice, the terms are often used interchangeably.",
+      wrongExplanations: {
+        0: "They are directly related — the ACR is produced by completing a VPAT template. They serve the same purpose: documenting a product's accessibility conformance.",
+        2: "This is reversed. The VPAT is the template; the ACR is the completed report. 'VPAT' refers to the template format, while 'ACR' refers to the filled-in evaluation.",
+        3: "Both VPAT and ACR are used internationally. There are different VPAT editions (Rev 508 for US, Rev EU for EN 301 549, Rev WCAG, and INT for international), but VPAT vs. ACR is template vs. completed report."
+      },
+      topicLinks: ['vpat', 'procurement-accessibility'],
+      difficulty: 'easy',
+      tags: ['procurement', 'vpat', 'acr']
+    },
+    {
+      id: 1230,
+      question: "Which VPAT conformance levels are used in an ACR to describe a product's accessibility?",
+      options: [
+        "Pass, Fail, Not Tested",
+        "Supports, Partially Supports, Does Not Support, Not Applicable",
+        "Conformant, Non-Conformant, Partially Conformant",
+        "Level A, Level AA, Level AAA"
+      ],
+      correct: 1,
+      explanation: "VPATs use four conformance levels: 'Supports' (meets the criterion), 'Partially Supports' (some functionality does not meet), 'Does Not Support' (majority does not meet), and 'Not Applicable' (criterion is not relevant to the product). Some VPATs also include 'Not Evaluated'.",
+      wrongExplanations: {
+        0: "Pass/Fail/Not Tested is not the VPAT conformance vocabulary. VPATs use more nuanced levels that distinguish between full and partial support.",
+        2: "Conformant/Non-Conformant is WCAG conformance terminology, not VPAT reporting terminology. VPATs use their own conformance levels.",
+        3: "A, AA, AAA are WCAG conformance levels. The VPAT uses them to identify which SC are being evaluated, but the reporting uses Supports/Partially Supports/Does Not Support/Not Applicable."
+      },
+      topicLinks: ['vpat', 'procurement-accessibility'],
+      difficulty: 'medium',
+      tags: ['procurement', 'vpat', 'acr']
+    },
+    {
+      id: 1231,
+      question: "Why should procurement teams treat vendor-provided VPATs/ACRs with some skepticism?",
+      options: [
+        "VPATs are legally binding documents, so vendors always exaggerate compliance",
+        "VPATs are self-reported by vendors and are NOT independently audited — claims should be verified with testing",
+        "VPATs are always outdated because they are only updated annually",
+        "VPATs only cover WCAG Level A, not Level AA"
+      ],
+      correct: 1,
+      explanation: "VPATs/ACRs are self-reported by the vendor — there is no requirement for independent third-party validation. While some vendors use independent accessibility professionals to create their ACRs, many do not. The quality and accuracy of ACRs varies significantly, so procurement teams should verify claims through their own testing or independent evaluation.",
+      wrongExplanations: {
+        0: "VPATs are voluntary, not legally binding. Vendors may overstate compliance, understate it, or produce inaccurate reports — which is why verification is important.",
+        2: "VPATs can be updated at any time and some vendors keep them current. The issue is not update frequency but the lack of independent verification.",
+        3: "VPATs cover whatever criteria the template edition specifies. The VPAT 2.4 Rev WCAG covers both A and AA criteria, and the INT version includes Section 508 and EN 301 549 as well."
+      },
+      topicLinks: ['vpat', 'procurement-accessibility'],
+      difficulty: 'medium',
+      tags: ['procurement', 'vpat', 'verification']
+    },
+    {
+      id: 1232,
+      question: "Which VPAT edition would be MOST appropriate for a European public sector organization evaluating a web application for compliance with the Web Accessibility Directive?",
+      options: [
+        "VPAT 2.4 Rev 508 — the US Section 508 version",
+        "VPAT 2.4 Rev WCAG — the WCAG-only version",
+        "VPAT 2.4 Rev EU — the EN 301 549 version",
+        "VPAT 2.4 INT — the international version combining all standards"
+      ],
+      correct: 2,
+      explanation: "The VPAT 2.4 Rev EU is specifically designed for EN 301 549, which is the harmonised European standard. The Web Accessibility Directive (2016/2102) references EN 301 549 for presumed conformance. While the INT version also covers EN 301 549, Rev EU is the most focused and relevant edition for European compliance.",
+      wrongExplanations: {
+        0: "Rev 508 is for US Section 508 compliance. European public sector bodies are subject to the Web Accessibility Directive and EN 301 549, not Section 508.",
+        1: "Rev WCAG covers WCAG criteria only. EN 301 549 includes additional requirements beyond WCAG that are relevant to the Web Accessibility Directive.",
+        3: "The INT version is comprehensive but includes Section 508 criteria that are not relevant to European compliance. Rev EU is more focused and appropriate for this context."
+      },
+      topicLinks: ['vpat', 'en-301-549', 'procurement-accessibility'],
+      difficulty: 'hard',
+      tags: ['procurement', 'vpat', 'en-301-549', 'european']
+    },
+    {
+      id: 1233,
+      question: "At what point in the procurement process is accessibility MOST effectively integrated?",
+      options: [
+        "After the contract is signed, during the implementation phase",
+        "During product evaluation and vendor selection, before the contract is signed",
+        "After deployment, during the first accessibility audit",
+        "Only when a user files an accessibility complaint"
+      ],
+      correct: 1,
+      explanation: "Accessibility is most effectively integrated during evaluation and selection — before the contract is signed. At this stage, the organization has maximum leverage to require accessibility features, evaluate vendor claims, request demonstrations, and include binding accessibility commitments in the contract. After signing, leverage decreases significantly.",
+      wrongExplanations: {
+        0: "After the contract is signed, the organization has less leverage to demand changes. Accessibility requirements and commitments should be established before signing.",
+        2: "Post-deployment audits are valuable but reactive. By that point, inaccessible features may be deeply embedded and expensive to fix. Prevention during procurement is more effective.",
+        3: "Waiting for complaints is the most reactive and costly approach. It also means users with disabilities have already been excluded."
+      },
+      topicLinks: ['procurement-accessibility', 'vpat'],
+      difficulty: 'easy',
+      tags: ['procurement', 'lifecycle']
+    },
+    {
+      id: 1234,
+      question: "What role can accessibility experts play in the procurement process?",
+      options: [
+        "Only evaluating vendor VPATs after the purchase decision is made",
+        "Advising on requirements, evaluating vendor responses and ACRs, testing products, suggesting contract language, and managing vendor remediation roadmaps",
+        "Writing the RFP document without input from the procurement team",
+        "Providing a single pass/fail rating for each vendor based on their VPAT"
+      ],
+      correct: 1,
+      explanation: "Accessibility experts contribute throughout the procurement lifecycle: advising on governance practices, helping define accessibility requirements in RFPs, evaluating vendor responses and ACRs, testing products independently, suggesting contract wording for accessibility commitments, and managing vendor relationships around defect remediation and accessibility roadmaps.",
+      wrongExplanations: {
+        0: "Evaluating VPATs is one part of the role, but accessibility experts should be involved much earlier — in defining requirements, drafting RFP questions, and evaluating responses before the purchase decision.",
+        2: "Accessibility experts should collaborate with the procurement team, not work in isolation. They provide accessibility-specific expertise to complement the procurement team's knowledge of organizational needs.",
+        3: "A single pass/fail rating oversimplifies the evaluation. Accessibility experts should provide nuanced analysis of which criteria are met, which are not, and the implications for users — enabling informed decision-making."
+      },
+      topicLinks: ['procurement-accessibility', 'vpat'],
+      difficulty: 'medium',
+      tags: ['procurement', 'expertise']
+    },
+    {
+      id: 1235,
+      question: "What is an accessibility maturity model?",
+      options: [
+        "A tool that measures the WCAG conformance level of a website",
+        "A framework for assessing an organization's capability to sustain accessibility across people, processes, and technology — not just code compliance",
+        "A testing methodology for evaluating assistive technology compatibility",
+        "A ranking system that compares different organizations' accessibility scores publicly"
+      ],
+      correct: 1,
+      explanation: "An accessibility maturity model assesses organizational capability — not just technical compliance. It evaluates how well accessibility is embedded across the organization's people (training, expertise, roles), processes (design, development, testing, procurement), and technology (tools, standards, infrastructure). The W3C WAI Accessibility Maturity Model is the primary reference.",
+      wrongExplanations: {
+        0: "WCAG conformance evaluation measures a website's compliance with technical criteria. A maturity model assesses the organization's ability to sustain accessibility over time.",
+        2: "Assistive technology testing methodologies assess product accessibility. Maturity models assess organizational capability and process integration.",
+        3: "Maturity models are for internal organizational assessment, not public competitive ranking. They help organizations identify gaps and improve their processes."
+      },
+      topicLinks: ['maturity-models', 'procurement-accessibility'],
+      difficulty: 'medium',
+      tags: ['maturity-models', 'organizational']
+    },
+    {
+      id: 1236,
+      question: "When a procured ICT product has known accessibility defects, which mitigation strategy is MOST appropriate?",
+      options: [
+        "Immediately terminate the contract and find a new vendor",
+        "Obtain a remediation roadmap from the vendor, include binding commitments in the contract, and provide alternative access for users in the interim",
+        "Accept the defects since no product is perfectly accessible",
+        "Block users with disabilities from accessing the product until defects are fixed"
+      ],
+      correct: 1,
+      explanation: "The appropriate approach is a multi-pronged mitigation strategy: obtain a specific, time-bound remediation roadmap from the vendor, include binding accessibility commitments in the contract (with consequences for non-compliance), put alternative access in place for users who need it now, and monitor the vendor's progress. This addresses both immediate user needs and long-term improvement.",
+      wrongExplanations: {
+        0: "Immediate termination may not be practical (contract terms, switching costs, limited alternatives). A remediation roadmap with contractual commitments is a more pragmatic first step.",
+        2: "Accepting defects without action means users with disabilities continue to be excluded. Known defects should be addressed through vendor commitments and interim mitigations.",
+        3: "Blocking users with disabilities is discriminatory and likely illegal. The goal is to provide access, not restrict it. Alternative access plans bridge the gap while defects are fixed."
+      },
+      topicLinks: ['procurement-accessibility', 'vpat', 'remediation-strategies'],
+      difficulty: 'hard',
+      tags: ['procurement', 'mitigation', 'remediation']
+    },
+    {
+      id: 1237,
+      question: "How does integrating accessibility in procurement differ from integrating it in development?",
+      options: [
+        "Procurement focuses on evaluating third-party products' accessibility and influencing vendor behavior through contracts, while development focuses on building accessibility into your own code",
+        "There is no difference — both involve running automated accessibility scans",
+        "Procurement only requires checking VPATs; development requires full WCAG conformance testing",
+        "Procurement accessibility is optional; development accessibility is legally required"
+      ],
+      correct: 0,
+      explanation: "Procurement accessibility focuses on evaluating products and services built by others — reviewing vendor claims (ACRs/VPATs), testing third-party products, setting accessibility requirements in RFPs, and using contract terms to drive vendor compliance. Development accessibility focuses on building accessible products directly through design, coding, and testing. Both are essential for an organization's overall accessibility posture.",
+      wrongExplanations: {
+        1: "Automated scans are one small part of both processes. Procurement involves evaluating vendor claims, negotiating contracts, and managing remediation roadmaps — activities very different from code development.",
+        2: "VPATs alone are insufficient for procurement evaluation — independent testing should verify vendor claims. And development also uses VPATs when the team produces conformance reports for their own products.",
+        3: "Neither is optional in organizations subject to accessibility laws. Legal frameworks like the EU EAA and US Section 508 include procurement requirements alongside development requirements."
+      },
+      topicLinks: ['procurement-accessibility', 'accessibility-qa-lifecycle'],
+      difficulty: 'medium',
+      tags: ['procurement', 'lifecycle', 'organizational']
+    },
+    {
+      id: 1238,
+      question: "The European Accessibility Act (EAA) enters into force in June 2025. How does it affect procurement?",
+      options: [
+        "It only applies to government websites, not commercial products",
+        "It expands accessibility requirements to private sector products and services, increasing the importance of accessibility in procurement for organizations selling to or operating in the EU",
+        "It replaces EN 301 549 entirely with a new standard",
+        "It eliminates the need for VPATs in European procurement"
+      ],
+      correct: 1,
+      explanation: "The European Accessibility Act (EAA, Directive 2019/882) extends accessibility requirements beyond public sector websites (covered by the Web Accessibility Directive) to private sector products and services — including e-commerce, banking, transport, and telecommunications. This significantly broadens the scope of accessibility procurement requirements for organizations operating in the EU.",
+      wrongExplanations: {
+        0: "The EAA specifically extends beyond government to the private sector. The Web Accessibility Directive (2016/2102) already covers government websites; the EAA adds commercial products and services.",
+        2: "The EAA does not replace EN 301 549 — EN 301 549 is being updated (under Mandate 587) to support the EAA's requirements alongside its existing role under the Web Accessibility Directive.",
+        3: "VPATs (specifically the Rev EU edition for EN 301 549) remain relevant for procurement. The EAA does not change the VPAT template system — it changes which organizations and products need to comply."
+      },
+      topicLinks: ['procurement-accessibility', 'en-301-549'],
+      difficulty: 'hard',
+      tags: ['procurement', 'eaa', 'en-301-549', 'european']
+    },
+    {
+      id: 1239,
+      question: "What is the W3C WAI Accessibility Maturity Model's procurement dimension primarily used to assess?",
+      options: [
+        "Whether the organization's website meets WCAG Level AA",
+        "How well the organization integrates accessibility into sourcing, negotiation, and selection of goods and services",
+        "The number of accessibility experts employed by the organization",
+        "Whether vendors have submitted VPATs for all their products"
+      ],
+      correct: 1,
+      explanation: "The W3C WAI Accessibility Maturity Model's procurement dimension evaluates how the organization uses accessibility processes, criteria, contract language, and decision-making to procure and maintain accessible products and services throughout the procurement lifecycle. It assesses organizational practice, not just individual product compliance.",
+      wrongExplanations: {
+        0: "WCAG conformance is assessed through technical evaluation, not maturity modeling. The maturity model evaluates the organization's procurement processes, not website compliance.",
+        2: "The number of experts is one aspect but not the primary assessment. The procurement dimension evaluates processes, criteria, and decision-making practices comprehensively.",
+        3: "VPAT submission is one data point but not what the procurement dimension assesses. It evaluates the overall procurement process — from requirements definition through vendor selection and ongoing management."
+      },
+      topicLinks: ['maturity-models', 'procurement-accessibility'],
+      difficulty: 'hard',
+      tags: ['maturity-models', 'procurement', 'organizational']
+    },
+    {
+      id: 1240,
+      question: "An organization wants to ensure long-term accessibility improvement, not just one-time compliance. Which combination of approaches is MOST effective?",
+      options: [
+        "Run annual automated scans and fix any new issues found",
+        "Hire an external consultant to perform a one-time comprehensive audit",
+        "Integrate accessibility into the development lifecycle, use a maturity model to track organizational progress, include accessibility in procurement, and involve users with disabilities in testing",
+        "Create an accessibility policy document and distribute it to all employees"
+      ],
+      correct: 2,
+      explanation: "Sustained accessibility requires a comprehensive approach: integrating accessibility into every stage of the development lifecycle (shift-left), measuring organizational maturity over time, ensuring procured products meet accessibility standards, and involving real users with disabilities. Each element addresses a different dimension — code, process, supply chain, and user validation.",
+      wrongExplanations: {
+        0: "Annual automated scans miss the majority of accessibility issues and provide only a snapshot. They do not address process improvement, procurement, or organizational capability.",
+        1: "A one-time audit provides a valuable baseline but does not ensure sustained improvement. Without process changes, the same issues recur in new development.",
+        3: "Policy documents are a necessary foundation but insufficient alone. Without integration into actual processes (development, procurement, testing), policies remain aspirational."
+      },
+      topicLinks: ['accessibility-qa-lifecycle', 'maturity-models', 'procurement-accessibility'],
+      difficulty: 'hard',
+      tags: ['organizational', 'maturity-models', 'lifecycle', 'remediation']
+    }
+  ]
+};


### PR DESCRIPTION
This pull request expands the Universal Design for Learning (UDL) content and updates the application to support additional WAS domain questions and new UDL-related topics. The most significant changes include the addition of a new question set focused on UDL principles, updates to the domain configuration arrays, and enhancements to the dashboard icon set.

**New UDL Content and Domain Expansion:**

* Added 10 new UDL-focused questions (IDs 291–300) to `cpacc-domain2`, covering UDL principles, brain networks, checkpoints, and assessment design, with detailed explanations and tags for each question.
* Included `wasDomain3` in the imports and added it to the `WAS_DOMAINS` array, ensuring the app recognizes and loads questions from this new domain. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R18) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L27-R28)

**Dashboard and Icon Enhancements:**

* Added the `Wrench` icon from `lucide-react` and mapped it in the `ICON_MAP` in `DomainCard.jsx`, allowing for new visual representations of domains or topics. [[1]](diffhunk://#diff-206ef3caca54a8fcf800575b706369e216101e1640a287e831702ab49bbbfd44L2-R2) [[2]](diffhunk://#diff-206ef3caca54a8fcf800575b706369e216101e1640a287e831702ab49bbbfd44R11)