### PR TITLE
Refactor active course state management to use local storage

### DIFF
--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -19,7 +19,8 @@ const COURSE_INFO = {
 
 export default function Dashboard({ cpaccDomains, wasDomains, stats, missedBank, flaggedBank, onStartReview }) {
   const headingRef = useRef(null);
-  const [activeCourse, setActiveCourse] = useLocalStorage('pourcast-course', 'cpacc');
+  const [storedCourse, setActiveCourse] = useLocalStorage('pourcast-course', 'cpacc');
+  const activeCourse = COURSE_INFO[storedCourse] ? storedCourse : 'cpacc';
 
   usePageFocus(headingRef);
 

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { usePageFocus } from '../../hooks/usePageFocus';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import DomainCard from './DomainCard';
 import MissedBankCard from './MissedBankCard';
 import FlaggedBankCard from './FlaggedBankCard';
@@ -18,7 +19,7 @@ const COURSE_INFO = {
 
 export default function Dashboard({ cpaccDomains, wasDomains, stats, missedBank, flaggedBank, onStartReview }) {
   const headingRef = useRef(null);
-  const [activeCourse, setActiveCourse] = useState('cpacc');
+  const [activeCourse, setActiveCourse] = useLocalStorage('pourcast-course', 'cpacc');
 
   usePageFocus(headingRef);
 


### PR DESCRIPTION
Closes #23 - This pull request updates the `Dashboard` component to persist the selected course across sessions by storing it in local storage, and removes an unused import.

Enhancements to course selection persistence:

* Replaced the use of `useState` with `useLocalStorage` for the `activeCourse` state in `Dashboard.jsx`, so the user's selected course is saved in local storage and restored on page reload.
* Added the import for `useLocalStorage` and removed the unused `useState` import from `Dashboard.jsx`.