### PR TITLE
Add WAS BoK Domain Three topics and practice exam configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ src/assets/fonts/
 .env
 .env.local
 *.log
+.playwright-mcp/
+playwright-profile/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ const KnowledgeHome = lazy(() => import('./components/knowledge/KnowledgeHome'))
 const TopicPage = lazy(() => import('./components/knowledge/TopicPage'));
 const FlaggedQuestionsPage = lazy(() => import('./components/flagged/FlaggedQuestionsPage'));
 const ActivityPage = lazy(() => import('./components/activity/ActivityPage'));
+const PracticeLayout = lazy(() => import('./components/practice/PracticeLayout'));
 
 const CPACC_DOMAINS = [domain1, domain2, domain3];
 const WAS_DOMAINS = [wasDomain1, wasDomain2, wasDomain3];
@@ -102,6 +103,26 @@ export default function App() {
     [setStats]
   );
 
+  // Mock exams award XP and count toward the streak, but stay out of
+  // domainStats/completedDomains/recentLessons (those are lesson-shaped).
+  const recordPracticeCompletion = useCallback((courseId, score) => {
+    setStats((prev) => {
+      const today = getLocalDateString();
+      const yesterday = getYesterdayDateString();
+      const isNewDay = prev.lastStudyDate !== today;
+      let streak = prev.streak || 0;
+      if (isNewDay) {
+        streak = prev.lastStudyDate === yesterday ? streak + 1 : 1;
+      }
+      return {
+        ...prev,
+        xp: (prev.xp || 0) + score * 10,
+        streak,
+        lastStudyDate: today,
+      };
+    });
+  }, [setStats]);
+
   const startReview = useCallback((courseId) => {
     const missedIds = missedBank.getMissedIds(courseId);
     const questions = getQuestionsByIds(missedIds, ALL_DOMAINS);
@@ -156,6 +177,16 @@ export default function App() {
             <Route
               path="/results"
               element={<SuccessScreen quiz={quiz} />}
+            />
+            <Route
+              path="/practice/*"
+              element={
+                <PracticeLayout
+                  allDomains={ALL_DOMAINS}
+                  domainsByCourse={DOMAINS_BY_COURSE}
+                  onPracticeComplete={recordPracticeCompletion}
+                />
+              }
             />
             <Route path="/learn" element={<KnowledgeHome />} />
             <Route path="/learn/:slug" element={<TopicPage />} />

--- a/src/components/common/LiveRegion.jsx
+++ b/src/components/common/LiveRegion.jsx
@@ -4,11 +4,19 @@ export const AnnounceContext = createContext(null);
 
 export default function LiveRegion({ children }) {
   const [message, setMessage] = useState('');
+  const [urgentMessage, setUrgentMessage] = useState('');
 
-  const announce = useCallback((text) => {
-    setMessage('');
-    // Brief delay ensures screen readers detect the change
-    requestAnimationFrame(() => setMessage(text));
+  // announce(text) is polite by default; announce(text, 'assertive') interrupts
+  // (reserved for urgent messages like final time warnings).
+  const announce = useCallback((text, priority = 'polite') => {
+    if (priority === 'assertive') {
+      setUrgentMessage('');
+      requestAnimationFrame(() => setUrgentMessage(text));
+    } else {
+      setMessage('');
+      // Brief delay ensures screen readers detect the change
+      requestAnimationFrame(() => setMessage(text));
+    }
   }, []);
 
   return (
@@ -21,6 +29,14 @@ export default function LiveRegion({ children }) {
         className="sr-only"
       >
         {message}
+      </div>
+      <div
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {urgentMessage}
       </div>
     </AnnounceContext.Provider>
   );

--- a/src/components/common/ModalDialog.jsx
+++ b/src/components/common/ModalDialog.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Shared modal built on the native <dialog> element: focus trap, Escape to
+ * close, and focus restoration to the invoker all come from the platform.
+ * Initial focus goes to the first focusable child (or one with autoFocus).
+ */
+export default function ModalDialog({ isOpen, onClose, labelledBy, className = '', children }) {
+  const dialogRef = useRef(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  // Native close (Escape) needs to sync React state
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return undefined;
+    const handleClose = () => onCloseRef.current?.();
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, []);
+
+  function handleBackdropClick(e) {
+    if (e.target === dialogRef.current) {
+      dialogRef.current.close();
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={`practice-dialog ${className}`}
+      aria-labelledby={labelledBy}
+      onClick={handleBackdropClick}
+    >
+      {children}
+    </dialog>
+  );
+}

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -5,6 +5,7 @@ import DomainCard from './DomainCard';
 import MissedBankCard from './MissedBankCard';
 import FlaggedBankCard from './FlaggedBankCard';
 import CourseSelector from './CourseSelector';
+import PracticeTestCard from './PracticeTestCard';
 
 const COURSE_INFO = {
   cpacc: {
@@ -78,6 +79,10 @@ export default function Dashboard({ cpaccDomains, wasDomains, stats, missedBank,
                 </section>
               ) : null;
             })()}
+
+            <section aria-label="Mock exam" className="mb-6">
+              <PracticeTestCard courseId={courseKey} />
+            </section>
 
             <section aria-label="Study domains">
               <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-secondary)' }}>Domains</h2>

--- a/src/components/dashboard/PracticeTestCard.jsx
+++ b/src/components/dashboard/PracticeTestCard.jsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router-dom';
+import { ClipboardCheck, ArrowRight } from 'lucide-react';
+import { PRACTICE_CONFIG } from '../../data/practiceConfig';
+import { formatSpoken } from '../../utils/formatTime';
+
+/** Dashboard pointer to the full-length mock exam for a course. */
+export default function PracticeTestCard({ courseId }) {
+  const config = PRACTICE_CONFIG[courseId];
+  if (!config) return null;
+
+  return (
+    <Link
+      to="/practice"
+      className="flex items-center gap-4 rounded-xl border-2 p-4 no-underline transition-colors hover-surface"
+      style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}
+    >
+      <span
+        className="w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0"
+        style={{ backgroundColor: 'var(--bg-accent)' }}
+      >
+        <ClipboardCheck size={24} aria-hidden="true" style={{ color: 'var(--text-accent)' }} />
+      </span>
+      <span className="flex-1">
+        <span className="block text-base font-bold" style={{ color: 'var(--text-primary)' }}>
+          {config.courseLabel} Mock Exam
+        </span>
+        <span className="block text-base" style={{ color: 'var(--text-muted)' }}>
+          {config.totalQuestions} questions · {formatSpoken(config.timeLimitSec)} · timed, exam conditions
+        </span>
+      </span>
+      <ArrowRight size={20} aria-hidden="true" style={{ color: 'var(--text-muted)' }} />
+    </Link>
+  );
+}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { BookOpen, GraduationCap, Trophy, Star, Flame, Dumbbell, TrendingUp } from 'lucide-react';
+import { BookOpen, GraduationCap, Trophy, Star, Flame, Dumbbell, TrendingUp, ClipboardCheck } from 'lucide-react';
 import AccessibilityPanel from './AccessibilityPanel';
 
 export default function Header({ stats }) {
   const location = useLocation();
   const isLearn = location.pathname.startsWith('/learn');
+  const isPractice = location.pathname.startsWith('/practice');
   const isHome = location.pathname === '/';
 
   return (
@@ -36,8 +37,13 @@ export default function Header({ stats }) {
           <nav aria-label="Main navigation">
             <ul className="flex items-center gap-2 list-none m-0 p-0">
               <li>
-                <NavLink to="/" active={isHome} label="Practice">
+                <NavLink to="/" active={isHome} label="Quizzes">
                   <Dumbbell size={16} aria-hidden="true" />
+                </NavLink>
+              </li>
+              <li>
+                <NavLink to="/practice" active={isPractice} label="Mock Exams">
+                  <ClipboardCheck size={16} aria-hidden="true" />
                 </NavLink>
               </li>
               <li>

--- a/src/components/practice/PracticeHome.jsx
+++ b/src/components/practice/PracticeHome.jsx
@@ -1,0 +1,211 @@
+import { useState, useRef } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ClipboardCheck, Play, AlertTriangle, Clock, FileQuestion, Target } from 'lucide-react';
+import { usePageFocus } from '../../hooks/usePageFocus';
+import { useAnnounce } from '../../hooks/useAnnounce';
+import { PRACTICE_CONFIG } from '../../data/practiceConfig';
+import { formatClock, formatSpoken } from '../../utils/formatTime';
+import ScoreHistory from './ScoreHistory';
+
+export default function PracticeHome({ practice }) {
+  const headingRef = useRef(null);
+  usePageFocus(headingRef);
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <h1
+        ref={headingRef}
+        tabIndex={-1}
+        className="text-2xl font-bold mb-2 flex items-center gap-2"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        <ClipboardCheck size={28} aria-hidden="true" style={{ color: 'var(--text-accent)' }} />
+        Mock Exams
+      </h1>
+      <p className="text-base mb-8" style={{ color: 'var(--text-secondary)' }}>
+        Full-length, timed practice tests that mirror the real proctored exams: same question
+        counts, same domain weighting, same time limit, and no feedback until you finish. You can
+        pause anytime and resume later — your progress is saved on this device.
+      </p>
+
+      {Object.keys(PRACTICE_CONFIG).map((courseId) => (
+        <CourseSection key={courseId} courseId={courseId} practice={practice} />
+      ))}
+    </div>
+  );
+}
+
+function CourseSection({ courseId, practice }) {
+  const config = PRACTICE_CONFIG[courseId];
+  const summary = practice.getSessionSummary(courseId);
+  const notices = practice.notices.filter((n) => n.courseId === courseId);
+  const attempts = practice.history.filter((a) => a.courseId === courseId);
+
+  return (
+    <section aria-labelledby={`practice-${courseId}-heading`} className="mb-10">
+      <h2
+        id={`practice-${courseId}-heading`}
+        className="text-xl font-bold mb-3"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {config.courseLabel} Mock Exam
+      </h2>
+
+      {notices.map((notice) => (
+        <Notice key={notice.type} notice={notice} practice={practice} />
+      ))}
+
+      <div
+        className="rounded-xl border-2 p-5 mb-4"
+        style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}
+      >
+        <ul className="flex flex-wrap gap-x-6 gap-y-2 list-none m-0 p-0 mb-4">
+          <ExamFact icon={<FileQuestion size={16} aria-hidden="true" />} text={`${config.totalQuestions} questions`} />
+          <ExamFact icon={<Clock size={16} aria-hidden="true" />} text={formatSpoken(config.timeLimitSec)} />
+          <ExamFact icon={<Target size={16} aria-hidden="true" />} text={`${config.passPercent}% to pass`} />
+        </ul>
+
+        {summary ? (
+          <ResumeControls courseId={courseId} summary={summary} practice={practice} />
+        ) : (
+          <StartControls courseId={courseId} practice={practice} />
+        )}
+      </div>
+
+      <ScoreHistory
+        courseId={courseId}
+        courseLabel={config.courseLabel}
+        attempts={attempts}
+        onClear={() => practice.clearHistory(courseId)}
+      />
+    </section>
+  );
+}
+
+function ExamFact({ icon, text }) {
+  return (
+    <li className="flex items-center gap-1.5 text-base" style={{ color: 'var(--text-secondary)' }}>
+      <span style={{ color: 'var(--text-muted)' }}>{icon}</span>
+      {text}
+    </li>
+  );
+}
+
+function Notice({ notice, practice }) {
+  const messages = {
+    expired: 'Time ran out on your saved test while you were away, so it was submitted automatically.',
+    invalid: 'Your saved test could not be restored (the app\'s questions were updated), so it was cleared. Please start a fresh test.',
+  };
+  return (
+    <div
+      role="alert"
+      className="border-l-4 p-4 rounded-r-lg mb-4 flex items-start gap-2"
+      style={{ backgroundColor: 'var(--warning-bg)', borderColor: 'var(--warning-border)' }}
+    >
+      <AlertTriangle size={20} aria-hidden="true" style={{ color: 'var(--warning-text)', flexShrink: 0 }} />
+      <div className="flex-1">
+        <p className="text-base font-medium" style={{ color: 'var(--warning-text)' }}>
+          {messages[notice.type] || 'Something went wrong with your saved test.'}
+        </p>
+        {notice.type === 'expired' && notice.attemptId && (
+          <Link
+            to={`/practice/results/${notice.attemptId}`}
+            className="text-base font-medium underline"
+            style={{ color: 'var(--warning-text)' }}
+          >
+            See your results
+          </Link>
+        )}
+      </div>
+      <button
+        onClick={() => practice.dismissNotice(notice.courseId, notice.type)}
+        className="text-base font-medium px-2 py-1 rounded-lg hover-surface"
+        style={{ color: 'var(--warning-text)' }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+function StartControls({ courseId, practice }) {
+  const navigate = useNavigate();
+  const announce = useAnnounce();
+
+  function handleStart() {
+    if (practice.startTest(courseId)) {
+      navigate(`/practice/test/${courseId}`);
+    } else {
+      announce('Could not start the test. Please reload and try again.');
+    }
+  }
+
+  return (
+    <button
+      onClick={handleStart}
+      className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-base font-bold transition-colors"
+      style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+    >
+      <Play size={18} aria-hidden="true" />
+      Start mock exam
+    </button>
+  );
+}
+
+function ResumeControls({ courseId, summary, practice }) {
+  const [confirmingAbandon, setConfirmingAbandon] = useState(false);
+  const announce = useAnnounce();
+
+  return (
+    <div>
+      <p className="text-base font-medium mb-3" style={{ color: 'var(--text-primary)' }}>
+        Test in progress: {summary.answeredCount} of {summary.total} answered
+        {summary.flaggedCount > 0 ? `, ${summary.flaggedCount} flagged` : ''} —{' '}
+        {formatClock(summary.remainingSec)} remaining (paused)
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <Link
+          to={`/practice/test/${courseId}`}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-base font-bold no-underline transition-colors"
+          style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+        >
+          <Play size={18} aria-hidden="true" />
+          Resume test
+        </Link>
+        {confirmingAbandon ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="text-base font-medium" style={{ color: 'var(--error-text)' }}>
+              Abandon this test? Your answers will be lost.
+            </span>
+            <button
+              onClick={() => {
+                practice.abandonTest(courseId);
+                setConfirmingAbandon(false);
+                announce('Test abandoned');
+              }}
+              className="px-3 py-1.5 rounded-lg text-base font-bold border-2"
+              style={{ borderColor: 'var(--error-border)', color: 'var(--error-text)', backgroundColor: 'var(--error-bg)' }}
+            >
+              Yes, abandon
+            </button>
+            <button
+              onClick={() => setConfirmingAbandon(false)}
+              className="px-3 py-1.5 rounded-lg text-base font-medium border-2 hover-surface"
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+            >
+              Keep test
+            </button>
+          </span>
+        ) : (
+          <button
+            onClick={() => setConfirmingAbandon(true)}
+            className="px-4 py-2.5 rounded-xl text-base font-medium border-2 hover-surface"
+            style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+          >
+            Abandon test
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/practice/PracticeLayout.jsx
+++ b/src/components/practice/PracticeLayout.jsx
@@ -1,0 +1,27 @@
+import { Routes, Route, useMatch } from 'react-router-dom';
+import { usePracticeTest } from '../../hooks/usePracticeTest';
+import { PRACTICE_CONFIG } from '../../data/practiceConfig';
+import PracticeHome from './PracticeHome';
+import PracticeTestView from './PracticeTestView';
+import PracticeResults from './PracticeResults';
+
+/**
+ * Owns the single usePracticeTest instance for all /practice routes so the
+ * session, timer, and history state are shared (and never duplicated against
+ * the same localStorage keys).
+ */
+export default function PracticeLayout({ allDomains, domainsByCourse, onPracticeComplete }) {
+  const match = useMatch('/practice/test/:courseId');
+  const matchedCourse = match?.params?.courseId;
+  const activeCourseId = matchedCourse && PRACTICE_CONFIG[matchedCourse] ? matchedCourse : null;
+
+  const practice = usePracticeTest(allDomains, domainsByCourse, activeCourseId, onPracticeComplete);
+
+  return (
+    <Routes>
+      <Route index element={<PracticeHome practice={practice} />} />
+      <Route path="test/:courseId" element={<PracticeTestView practice={practice} courseId={activeCourseId} />} />
+      <Route path="results/:attemptId" element={<PracticeResults practice={practice} allDomains={allDomains} />} />
+    </Routes>
+  );
+}

--- a/src/components/practice/PracticeQuestionCard.jsx
+++ b/src/components/practice/PracticeQuestionCard.jsx
@@ -1,0 +1,181 @@
+import { useRef, useEffect } from 'react';
+import { Flag, Ban } from 'lucide-react';
+
+/**
+ * Exam-mode question card: no feedback, answers can be changed, options can
+ * be eliminated (struck through) as a test-taking strategy, and the question
+ * can be flagged for review. Options are native radios (visually hidden
+ * inputs inside styled labels) so changeable single-select semantics and
+ * arrow-key behavior come from the platform.
+ */
+export default function PracticeQuestionCard({
+  question,
+  questionIndex,
+  totalQuestions,
+  selectedIndex,
+  eliminatedIndices = [],
+  isFlagged,
+  onSelect,
+  onToggleEliminate,
+  onToggleFlag,
+}) {
+  const headingRef = useRef(null);
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, [question.id]);
+
+  function handleKeyDown(e) {
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    const key = e.key.toLowerCase();
+
+    if (key === 'f') {
+      onToggleFlag();
+      e.preventDefault();
+      return;
+    }
+
+    let idx = -1;
+    if (/^[a-d]$/.test(key)) {
+      idx = key.charCodeAt(0) - 97;
+    } else if (/^Digit[1-4]$/.test(e.code)) {
+      // e.code survives Shift (Shift+1 makes e.key '!')
+      idx = parseInt(e.code.slice(5), 10) - 1;
+    } else if (/^Numpad[1-4]$/.test(e.code)) {
+      idx = parseInt(e.code.slice(6), 10) - 1;
+    }
+
+    if (idx >= 0 && idx < question.options.length) {
+      if (e.shiftKey) {
+        onToggleEliminate(idx);
+      } else {
+        onSelect(idx);
+      }
+      e.preventDefault();
+    }
+  }
+
+  function getOptionStyles(isSelected, isEliminated) {
+    const base = {
+      width: '100%',
+      textAlign: 'left',
+      padding: '1rem',
+      borderRadius: '0.75rem',
+      border: '2px solid',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.75rem',
+      transition: 'all 0.15s',
+      cursor: 'pointer',
+    };
+    if (isSelected) {
+      return { ...base, borderColor: 'var(--text-accent)', backgroundColor: 'var(--bg-accent)', color: 'var(--text-primary)' };
+    }
+    if (isEliminated) {
+      return { ...base, borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface-hover)', color: 'var(--text-muted)' };
+    }
+    return { ...base, borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)', color: 'var(--text-primary)' };
+  }
+
+  return (
+    <div onKeyDown={handleKeyDown}>
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <p className="text-base font-semibold" style={{ color: 'var(--text-muted)' }}>
+          Question {questionIndex + 1} of {totalQuestions}
+        </p>
+        <button
+          onClick={onToggleFlag}
+          aria-pressed={isFlagged}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-base font-medium border-2 transition-colors"
+          style={{
+            borderColor: isFlagged ? 'var(--warning-border)' : 'var(--border-default)',
+            backgroundColor: isFlagged ? 'var(--warning-bg)' : 'transparent',
+            color: isFlagged ? 'var(--warning-text)' : 'var(--text-secondary)',
+          }}
+        >
+          <Flag size={16} aria-hidden="true" fill={isFlagged ? 'currentColor' : 'none'} />
+          {isFlagged ? 'Flagged' : 'Flag for review'}
+        </button>
+      </div>
+
+      <h2
+        ref={headingRef}
+        tabIndex={-1}
+        className="text-xl font-bold mb-6 leading-relaxed"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {question.question}
+      </h2>
+
+      <fieldset className="border-0 m-0 p-0">
+        <legend className="sr-only">
+          Answer choices for question {questionIndex + 1}
+        </legend>
+        <div className="space-y-3">
+          {question.options.map((option, i) => {
+            const letter = String.fromCharCode(65 + i);
+            const isSelected = selectedIndex === i;
+            const isEliminated = eliminatedIndices.includes(i);
+            return (
+              <div key={i} className="flex items-stretch gap-2">
+                <label className="practice-option flex-1 rounded-xl" style={getOptionStyles(isSelected, isEliminated)}>
+                  <input
+                    type="radio"
+                    className="sr-only"
+                    name={`practice-q-${question.id}`}
+                    checked={isSelected}
+                    onChange={() => onSelect(i)}
+                  />
+                  <span
+                    className="w-7 h-7 rounded-full text-base font-bold flex items-center justify-center flex-shrink-0"
+                    style={{
+                      backgroundColor: isSelected ? 'var(--btn-accent)' : 'var(--bg-surface-hover)',
+                      color: isSelected ? 'var(--text-on-accent)' : 'var(--text-muted)',
+                    }}
+                  >
+                    {letter}
+                  </span>
+                  <span
+                    className="flex-1"
+                    style={isEliminated ? { textDecoration: 'line-through' } : undefined}
+                  >
+                    {option}
+                    {isEliminated && <span className="sr-only"> (eliminated)</span>}
+                  </span>
+                </label>
+                <button
+                  onClick={() => onToggleEliminate(i)}
+                  aria-pressed={isEliminated}
+                  aria-label={`Eliminate option ${letter}`}
+                  className="px-3 rounded-xl border-2 transition-colors hover-surface flex items-center"
+                  style={{
+                    borderColor: isEliminated ? 'var(--border-strong)' : 'var(--border-default)',
+                    backgroundColor: isEliminated ? 'var(--bg-surface-hover)' : 'transparent',
+                    color: 'var(--text-muted)',
+                  }}
+                >
+                  <Ban size={18} aria-hidden="true" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <details className="mt-5">
+        <summary
+          className="text-base font-medium cursor-pointer"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          Keyboard shortcuts
+        </summary>
+        <ul className="mt-2 ml-4 space-y-1 list-disc text-base" style={{ color: 'var(--text-secondary)' }}>
+          <li>1–4 or A–D: select an answer</li>
+          <li>Shift + 1–4 (or Shift + A–D): eliminate or restore an answer</li>
+          <li>F: flag or unflag this question</li>
+          <li>Arrow keys: move between answer choices</li>
+        </ul>
+      </details>
+    </div>
+  );
+}

--- a/src/components/practice/PracticeResults.jsx
+++ b/src/components/practice/PracticeResults.jsx
@@ -1,0 +1,289 @@
+import { useState, useRef, useMemo } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Trophy, AlertCircle, CheckCircle, XCircle, Ban, Flag, Clock } from 'lucide-react';
+import { usePageFocus } from '../../hooks/usePageFocus';
+import { PRACTICE_CONFIG } from '../../data/practiceConfig';
+import { resolveEntries } from '../../utils/practiceDraw';
+import { formatSpoken } from '../../utils/formatTime';
+import TopicLinks from '../quiz/TopicLinks';
+
+const FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'incorrect', label: 'Incorrect' },
+  { key: 'unanswered', label: 'Unanswered' },
+  { key: 'flagged', label: 'Flagged' },
+];
+
+export default function PracticeResults({ practice, allDomains }) {
+  const { attemptId } = useParams();
+  const headingRef = useRef(null);
+  usePageFocus(headingRef);
+  const [filter, setFilter] = useState('all');
+
+  const attempt = practice.getAttempt(attemptId);
+
+  const reviewItems = useMemo(() => {
+    if (!attempt?.detail) return null;
+    const { entries, answers, flagged, eliminated } = attempt.detail;
+    const { questions } = resolveEntries(entries, allDomains);
+    const byId = new Map(questions.map((q) => [q.id, q]));
+    return entries.map((entry, i) => {
+      const question = byId.get(entry.qid) || null;
+      const selected = answers?.[entry.qid];
+      return {
+        number: i + 1,
+        question,
+        selected: selected === undefined ? null : selected,
+        isCorrect: question ? selected === question.correct : false,
+        isFlagged: (flagged || []).includes(entry.qid),
+        eliminatedIndices: eliminated?.[entry.qid] || [],
+      };
+    });
+  }, [attempt, allDomains]);
+
+  if (!attempt) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-12 text-center">
+        <h1 className="text-2xl font-bold mb-3" style={{ color: 'var(--text-primary)' }}>
+          Attempt not found
+        </h1>
+        <p className="text-base mb-6" style={{ color: 'var(--text-secondary)' }}>
+          This attempt may have been cleared from your history.
+        </p>
+        <Link
+          to="/practice"
+          className="font-medium underline text-base"
+          style={{ color: 'var(--text-accent)' }}
+        >
+          Back to Mock Exams
+        </Link>
+      </div>
+    );
+  }
+
+  const config = PRACTICE_CONFIG[attempt.courseId];
+  const domainTitles = new Map(allDomains.map((d) => [d.id, d.title]));
+
+  const counts = reviewItems
+    ? {
+        all: reviewItems.length,
+        incorrect: reviewItems.filter((r) => !r.isCorrect && r.selected !== null).length,
+        unanswered: reviewItems.filter((r) => r.selected === null).length,
+        flagged: reviewItems.filter((r) => r.isFlagged).length,
+      }
+    : null;
+
+  const visibleItems = reviewItems
+    ? reviewItems.filter((r) => {
+        if (filter === 'incorrect') return !r.isCorrect && r.selected !== null;
+        if (filter === 'unanswered') return r.selected === null;
+        if (filter === 'flagged') return r.isFlagged;
+        return true;
+      })
+    : null;
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <div className="text-center mb-8">
+        {attempt.passed ? (
+          <Trophy size={48} aria-hidden="true" className="mx-auto mb-3" style={{ color: 'var(--success-icon)' }} />
+        ) : (
+          <AlertCircle size={48} aria-hidden="true" className="mx-auto mb-3" style={{ color: 'var(--warning-text)' }} />
+        )}
+        <h1
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-2xl font-bold mb-2"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {attempt.passed ? 'Passed' : 'Not passed'} — {attempt.score}/{attempt.total} ({attempt.percentage}%)
+        </h1>
+        <p className="text-base" style={{ color: 'var(--text-secondary)' }}>
+          The real {config?.courseLabel || attempt.courseId.toUpperCase()} exam requires {config?.passPercent}% to pass.
+          {attempt.passed
+            ? ' Excellent work — keep this up and you\'re ready for the real thing.'
+            : ' Keep going — review the questions below and hit the Study Shelf topics that tripped you up.'}
+        </p>
+        <p className="text-base mt-2 inline-flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
+          <Clock size={16} aria-hidden="true" />
+          Time used: {formatSpoken(attempt.durationUsedSec)}
+          {attempt.autoSubmitted && ' (time ran out — submitted automatically)'}
+        </p>
+      </div>
+
+      <h2 className="text-xl font-bold mb-3" style={{ color: 'var(--text-primary)' }}>
+        Results by domain
+      </h2>
+      <div className="overflow-x-auto mb-8">
+        <table className="w-full text-base" style={{ color: 'var(--text-primary)' }}>
+          <caption className="sr-only">Score breakdown by exam domain</caption>
+          <thead>
+            <tr className="text-left" style={{ color: 'var(--text-muted)' }}>
+              <th scope="col" className="py-2 pr-4 font-semibold">Domain</th>
+              <th scope="col" className="py-2 pr-4 font-semibold">Correct</th>
+              <th scope="col" className="py-2 font-semibold">Percent</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(attempt.perDomain || {}).map(([domainId, d]) => (
+              <tr key={domainId} style={{ borderTop: '1px solid var(--border-default)' }}>
+                <td className="py-2.5 pr-4">{domainTitles.get(domainId) || domainId}</td>
+                <td className="py-2.5 pr-4">{d.correct}/{d.total}</td>
+                <td className="py-2.5">{d.total > 0 ? Math.round((d.correct / d.total) * 100) : 0}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {reviewItems ? (
+        <section aria-labelledby="review-heading">
+          <h2 id="review-heading" className="text-xl font-bold mb-3" style={{ color: 'var(--text-primary)' }}>
+            Review your answers
+          </h2>
+          <div className="flex flex-wrap gap-2 mb-5" role="group" aria-label="Filter reviewed questions">
+            {FILTERS.map((f) => (
+              <button
+                key={f.key}
+                onClick={() => setFilter(f.key)}
+                aria-pressed={filter === f.key}
+                className="px-3 py-1.5 rounded-full text-base font-medium border-2 transition-colors"
+                style={{
+                  borderColor: filter === f.key ? 'var(--text-accent)' : 'var(--border-default)',
+                  backgroundColor: filter === f.key ? 'var(--bg-accent)' : 'transparent',
+                  color: filter === f.key ? 'var(--text-accent)' : 'var(--text-secondary)',
+                }}
+              >
+                {f.label} ({counts[f.key]})
+              </button>
+            ))}
+          </div>
+
+          {visibleItems.length === 0 ? (
+            <p className="text-base" style={{ color: 'var(--text-muted)' }}>
+              No questions match this filter.
+            </p>
+          ) : (
+            <div className="space-y-6">
+              {visibleItems.map((item) => (
+                <ReviewQuestionItem key={item.number} item={item} />
+              ))}
+            </div>
+          )}
+        </section>
+      ) : (
+        <p className="text-base" style={{ color: 'var(--text-muted)' }}>
+          Question-by-question review is only kept for your most recent attempt of each exam.
+        </p>
+      )}
+
+      <div className="mt-10 text-center">
+        <Link
+          to="/practice"
+          className="font-medium underline text-base"
+          style={{ color: 'var(--text-accent)' }}
+        >
+          Back to Mock Exams
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ReviewQuestionItem({ item }) {
+  const { number, question, selected, isCorrect, isFlagged, eliminatedIndices } = item;
+
+  if (!question) {
+    return (
+      <div
+        className="rounded-xl border-2 p-4"
+        style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}
+      >
+        <p className="text-base" style={{ color: 'var(--text-muted)' }}>
+          Question {number} is no longer available (it was changed in an app update).
+        </p>
+      </div>
+    );
+  }
+
+  const statusLabel = selected === null ? 'Unanswered' : isCorrect ? 'Correct' : 'Incorrect';
+  const statusColor = selected === null
+    ? 'var(--text-muted)'
+    : isCorrect ? 'var(--success-text)' : 'var(--error-text)';
+
+  return (
+    <div
+      className="rounded-xl border-2 p-5"
+      style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}
+    >
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
+        <h3 className="text-base font-bold m-0" style={{ color: statusColor }}>
+          Question {number} — {statusLabel}
+        </h3>
+        {isFlagged && (
+          <span
+            className="inline-flex items-center gap-1 text-base font-medium px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: 'var(--warning-bg)', color: 'var(--warning-text)' }}
+          >
+            <Flag size={12} aria-hidden="true" fill="currentColor" />
+            Flagged
+          </span>
+        )}
+      </div>
+
+      <p className="text-base font-semibold mb-3 leading-relaxed" style={{ color: 'var(--text-primary)' }}>
+        {question.question}
+      </p>
+
+      <ul className="space-y-2 list-none m-0 p-0 mb-4">
+        {question.options.map((option, i) => {
+          const isCorrectOption = i === question.correct;
+          const isYourPick = i === selected;
+          const wasEliminated = eliminatedIndices.includes(i);
+          return (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-base rounded-lg px-3 py-2"
+              style={{
+                backgroundColor: isCorrectOption
+                  ? 'var(--success-bg)'
+                  : isYourPick ? 'var(--error-bg)' : 'transparent',
+                color: isCorrectOption
+                  ? 'var(--success-text)'
+                  : isYourPick ? 'var(--error-text)' : 'var(--text-secondary)',
+              }}
+            >
+              {isCorrectOption ? (
+                <CheckCircle size={18} aria-hidden="true" className="flex-shrink-0 mt-0.5" style={{ color: 'var(--success-icon)' }} />
+              ) : isYourPick ? (
+                <XCircle size={18} aria-hidden="true" className="flex-shrink-0 mt-0.5" style={{ color: 'var(--error-icon)' }} />
+              ) : wasEliminated ? (
+                <Ban size={18} aria-hidden="true" className="flex-shrink-0 mt-0.5" style={{ color: 'var(--text-muted)' }} />
+              ) : (
+                <span className="w-[18px] flex-shrink-0" aria-hidden="true" />
+              )}
+              <span style={wasEliminated && !isCorrectOption && !isYourPick ? { textDecoration: 'line-through' } : undefined}>
+                <strong>{String.fromCharCode(65 + i)}.</strong> {option}
+                {isCorrectOption && <span className="font-semibold"> — correct answer</span>}
+                {isYourPick && !isCorrectOption && <span className="font-semibold"> — your answer</span>}
+                {isYourPick && isCorrectOption && <span className="font-semibold"> (your answer)</span>}
+                {wasEliminated && <span className="sr-only"> (you eliminated this option)</span>}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="text-base leading-relaxed mb-2" style={{ color: 'var(--text-secondary)' }}>
+        <strong style={{ color: 'var(--text-primary)' }}>Why:</strong> {question.explanation}
+      </p>
+      {selected !== null && !isCorrect && question.wrongExplanations?.[selected] && (
+        <p className="text-base leading-relaxed mb-2" style={{ color: 'var(--text-secondary)' }}>
+          <strong style={{ color: 'var(--text-primary)' }}>About your answer:</strong>{' '}
+          {question.wrongExplanations[selected]}
+        </p>
+      )}
+      <TopicLinks slugs={question.topicLinks} />
+    </div>
+  );
+}

--- a/src/components/practice/PracticeTestView.jsx
+++ b/src/components/practice/PracticeTestView.jsx
@@ -1,0 +1,270 @@
+import { useState, useEffect, useRef } from 'react';
+import { Navigate, useNavigate, Link } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, Pause, Play, LayoutGrid, Send, AlertTriangle } from 'lucide-react';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useAnnounce } from '../../hooks/useAnnounce';
+import { PRACTICE_CONFIG } from '../../data/practiceConfig';
+import { formatClock } from '../../utils/formatTime';
+import TimerBar from './TimerBar';
+import PracticeQuestionCard from './PracticeQuestionCard';
+import QuestionNavigator from './QuestionNavigator';
+import SubmitConfirmDialog from './SubmitConfirmDialog';
+
+export default function PracticeTestView({ practice, courseId }) {
+  const navigate = useNavigate();
+  const announce = useAnnounce();
+  const [prefs, setPrefs] = useLocalStorage('pourcast-practice-prefs', { version: 1, hideTimer: false });
+  const [navOpen, setNavOpen] = useState(false);
+  const [submitOpen, setSubmitOpen] = useState(false);
+  const submittingRef = useRef(false);
+
+  const {
+    session, invalidSession, questions, currentIndex, currentQuestion,
+    answers, flaggedIds, eliminatedMap, answeredCount, flaggedCount,
+    status, remainingSec, expiredAttempt, pauseTest,
+  } = practice;
+
+  // Leaving the test view = pausing (the clock should never run unseen)
+  useEffect(() => {
+    if (!courseId) return undefined;
+    return () => pauseTest(courseId);
+  }, [courseId, pauseTest]);
+
+  // Announce position as the user moves through the test
+  const currentQuestionId = currentQuestion?.id;
+  useEffect(() => {
+    if (currentQuestionId) {
+      announce(`Question ${currentIndex + 1} of ${questions.length}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentQuestionId]);
+
+  // Time expired while taking the test → auto-submitted by the hook
+  useEffect(() => {
+    if (expiredAttempt && expiredAttempt.courseId === courseId) {
+      announce('Time is up. Your test has been submitted.', 'assertive');
+      if (expiredAttempt.attemptId) {
+        navigate(`/practice/results/${expiredAttempt.attemptId}`, { replace: true });
+      } else {
+        navigate('/practice', { replace: true });
+      }
+    }
+  }, [expiredAttempt, courseId, announce, navigate]);
+
+  if (!courseId) return <Navigate to="/practice" replace />;
+
+  if (invalidSession) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-12">
+        <div
+          role="alert"
+          className="border-l-4 p-4 rounded-r-lg mb-5 flex items-start gap-2"
+          style={{ backgroundColor: 'var(--warning-bg)', borderColor: 'var(--warning-border)' }}
+        >
+          <AlertTriangle size={20} aria-hidden="true" style={{ color: 'var(--warning-text)', flexShrink: 0 }} />
+          <p className="text-base font-medium" style={{ color: 'var(--warning-text)' }}>
+            Your saved test referenced questions that were changed in an app update, so it can&apos;t
+            be restored. Sorry about that — please start a fresh test.
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            practice.abandonTest(courseId);
+            navigate('/practice');
+          }}
+          className="px-5 py-2.5 rounded-xl text-base font-bold"
+          style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+        >
+          Back to Mock Exams
+        </button>
+      </div>
+    );
+  }
+
+  if (!session || !currentQuestion) {
+    // While a just-submitted test navigates to results, the session is already
+    // cleared — render nothing rather than redirecting over that navigation.
+    if (submittingRef.current) return null;
+    return <Navigate to="/practice" replace />;
+  }
+
+  const config = PRACTICE_CONFIG[courseId];
+  const isPaused = status === 'paused';
+
+  function handleSubmit() {
+    submittingRef.current = true;
+    const attemptId = practice.submitTest();
+    setSubmitOpen(false);
+    if (attemptId) {
+      announce('Test submitted.');
+      navigate(`/practice/results/${attemptId}`, { replace: true });
+    } else {
+      navigate('/practice', { replace: true });
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6">
+      <h1 className="sr-only">{config.courseLabel} mock exam</h1>
+
+      <TimerBar
+        remainingSec={remainingSec ?? 0}
+        isRunning={status === 'active'}
+        hidden={Boolean(prefs.hideTimer)}
+        onToggleHidden={() => setPrefs((p) => ({ ...p, hideTimer: !p.hideTimer }))}
+      />
+
+      {isPaused ? (
+        <PausePanel
+          remainingSec={remainingSec ?? 0}
+          onResume={() => {
+            practice.resumeTest(courseId);
+            announce('Timer resumed.');
+          }}
+        />
+      ) : (
+        <>
+          <PracticeQuestionCard
+            question={currentQuestion}
+            questionIndex={currentIndex}
+            totalQuestions={questions.length}
+            selectedIndex={answers[currentQuestion.id] ?? null}
+            eliminatedIndices={eliminatedMap[currentQuestion.id] || []}
+            isFlagged={flaggedIds.includes(currentQuestion.id)}
+            onSelect={(i) => practice.selectAnswer(currentQuestion.id, i)}
+            onToggleEliminate={(i) => {
+              const wasEliminated = (eliminatedMap[currentQuestion.id] || []).includes(i);
+              practice.toggleEliminate(currentQuestion.id, i);
+              announce(wasEliminated
+                ? `Option ${String.fromCharCode(65 + i)} restored`
+                : `Option ${String.fromCharCode(65 + i)} eliminated`);
+            }}
+            onToggleFlag={() => {
+              const wasFlagged = flaggedIds.includes(currentQuestion.id);
+              practice.toggleFlag(currentQuestion.id);
+              announce(wasFlagged ? 'Flag removed' : 'Question flagged for review');
+            }}
+          />
+
+          <div className="flex items-center justify-between gap-3 flex-wrap mt-6">
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => practice.goTo(currentIndex - 1)}
+                disabled={currentIndex === 0}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-medium border-2 hover-surface disabled:opacity-50"
+                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                <ArrowLeft size={16} aria-hidden="true" />
+                Previous
+              </button>
+              <button
+                onClick={() => practice.goTo(currentIndex + 1)}
+                disabled={currentIndex >= questions.length - 1}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-medium border-2 hover-surface disabled:opacity-50"
+                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                Next
+                <ArrowRight size={16} aria-hidden="true" />
+              </button>
+            </div>
+
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                onClick={() => setNavOpen(true)}
+                aria-haspopup="dialog"
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-medium border-2 hover-surface"
+                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                <LayoutGrid size={16} aria-hidden="true" />
+                All questions ({answeredCount}/{questions.length} answered)
+              </button>
+              <button
+                onClick={() => {
+                  pauseTest(courseId);
+                  announce('Test paused. The timer is stopped.');
+                }}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-medium border-2 hover-surface"
+                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                <Pause size={16} aria-hidden="true" />
+                Pause
+              </button>
+              <button
+                onClick={() => setSubmitOpen(true)}
+                aria-haspopup="dialog"
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-bold"
+                style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+              >
+                <Send size={16} aria-hidden="true" />
+                Submit
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      <QuestionNavigator
+        isOpen={navOpen}
+        onClose={() => setNavOpen(false)}
+        questions={questions}
+        answers={answers}
+        flaggedIds={flaggedIds}
+        currentIndex={currentIndex}
+        answeredCount={answeredCount}
+        onNavigate={(i) => {
+          practice.goTo(i);
+          setNavOpen(false);
+        }}
+        onRequestSubmit={() => {
+          setNavOpen(false);
+          setSubmitOpen(true);
+        }}
+      />
+
+      <SubmitConfirmDialog
+        isOpen={submitOpen}
+        onClose={() => setSubmitOpen(false)}
+        onSubmit={handleSubmit}
+        answeredCount={answeredCount}
+        totalQuestions={questions.length}
+        flaggedCount={flaggedCount}
+      />
+    </div>
+  );
+}
+
+function PausePanel({ remainingSec, onResume }) {
+  return (
+    <div
+      className="rounded-xl border-2 p-8 text-center"
+      style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}
+    >
+      <h2 className="text-xl font-bold mb-2" style={{ color: 'var(--text-primary)' }}>
+        Test paused
+      </h2>
+      <p className="text-base mb-6" style={{ color: 'var(--text-secondary)' }}>
+        The timer is stopped at {formatClock(remainingSec)} remaining. Your questions are hidden
+        while you take a break, just like on the real exam. Your progress is saved — you can also
+        leave and resume another day.
+      </p>
+      <div className="flex items-center justify-center gap-3 flex-wrap">
+        <button
+          autoFocus
+          onClick={onResume}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-base font-bold"
+          style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+        >
+          <Play size={18} aria-hidden="true" />
+          Resume test
+        </button>
+        <Link
+          to="/practice"
+          className="px-4 py-2.5 rounded-xl text-base font-medium border-2 no-underline hover-surface"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+        >
+          Save and exit
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/practice/QuestionNavigator.jsx
+++ b/src/components/practice/QuestionNavigator.jsx
@@ -1,0 +1,87 @@
+import { Flag } from 'lucide-react';
+import ModalDialog from '../common/ModalDialog';
+
+/**
+ * Jump-to-question dialog. Plain buttons in a wrapping grid — every state
+ * (answered/unanswered/flagged/current) is in each button's accessible name,
+ * with the visual treatment as a parallel channel, never the only one.
+ */
+export default function QuestionNavigator({
+  isOpen,
+  onClose,
+  questions,
+  answers,
+  flaggedIds,
+  currentIndex,
+  onNavigate,
+  onRequestSubmit,
+  answeredCount,
+}) {
+  return (
+    <ModalDialog isOpen={isOpen} onClose={onClose} labelledBy="question-navigator-title">
+      <h2
+        id="question-navigator-title"
+        className="text-xl font-bold mb-1"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        Question navigator
+      </h2>
+      <p className="text-base mb-4" style={{ color: 'var(--text-secondary)' }}>
+        {answeredCount} of {questions.length} answered
+        {flaggedIds.length > 0 ? `, ${flaggedIds.length} flagged` : ''}.
+        Filled numbers are answered; a flag marks flagged questions.
+      </p>
+
+      <div className="flex flex-wrap gap-2 mb-5">
+        {questions.map((q, i) => {
+          const isAnswered = answers[q.id] !== undefined;
+          const isFlagged = flaggedIds.includes(q.id);
+          const isCurrent = i === currentIndex;
+          return (
+            <button
+              key={q.id}
+              onClick={() => onNavigate(i)}
+              aria-label={`Question ${i + 1}: ${isAnswered ? 'answered' : 'unanswered'}${isFlagged ? ', flagged' : ''}${isCurrent ? ', current question' : ''}`}
+              aria-current={isCurrent ? 'true' : undefined}
+              className="relative w-11 h-11 rounded-lg text-base font-bold flex items-center justify-center border-2 transition-colors"
+              style={{
+                borderColor: isCurrent ? 'var(--border-strong)' : isAnswered ? 'var(--text-accent)' : 'var(--border-default)',
+                backgroundColor: isAnswered ? 'var(--bg-accent)' : 'var(--bg-surface)',
+                color: isAnswered ? 'var(--text-accent)' : 'var(--text-secondary)',
+                boxShadow: isCurrent ? '0 0 0 2px var(--border-strong)' : 'none',
+              }}
+            >
+              <span aria-hidden="true">{i + 1}</span>
+              {isFlagged && (
+                <Flag
+                  size={12}
+                  aria-hidden="true"
+                  fill="currentColor"
+                  className="absolute -top-1.5 -right-1.5"
+                  style={{ color: 'var(--warning-text)' }}
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 rounded-xl text-base font-medium border-2 hover-surface"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+        >
+          Close
+        </button>
+        <button
+          onClick={onRequestSubmit}
+          className="px-4 py-2 rounded-xl text-base font-bold"
+          style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+        >
+          Submit test…
+        </button>
+      </div>
+    </ModalDialog>
+  );
+}

--- a/src/components/practice/ScoreHistory.jsx
+++ b/src/components/practice/ScoreHistory.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { CheckCircle, XCircle, TrendingUp } from 'lucide-react';
+
+/** Past mock exam attempts for one course, newest first. */
+export default function ScoreHistory({ courseLabel, attempts, onClear }) {
+  const [confirmingClear, setConfirmingClear] = useState(false);
+
+  if (attempts.length === 0) {
+    return (
+      <p className="text-base" style={{ color: 'var(--text-muted)' }}>
+        No {courseLabel} attempts yet. Your scores will appear here after your first mock exam.
+      </p>
+    );
+  }
+
+  const recent = attempts.slice(0, 5);
+  const avg = Math.round(recent.reduce((sum, a) => sum + a.percentage, 0) / recent.length);
+
+  return (
+    <div>
+      <h3 className="text-lg font-bold mb-2 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+        <TrendingUp size={18} aria-hidden="true" style={{ color: 'var(--text-muted)' }} />
+        Score history
+      </h3>
+      <p className="text-base mb-3" style={{ color: 'var(--text-muted)' }}>
+        Average of last {recent.length}: <strong style={{ color: 'var(--text-primary)' }}>{avg}%</strong>
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-base" style={{ color: 'var(--text-primary)' }}>
+          <caption className="sr-only">
+            {courseLabel} mock exam attempts, most recent first
+          </caption>
+          <thead>
+            <tr className="text-left" style={{ color: 'var(--text-muted)' }}>
+              <th scope="col" className="py-2 pr-4 font-semibold">Date</th>
+              <th scope="col" className="py-2 pr-4 font-semibold">Score</th>
+              <th scope="col" className="py-2 pr-4 font-semibold">Result</th>
+              <th scope="col" className="py-2 font-semibold">Review</th>
+            </tr>
+          </thead>
+          <tbody>
+            {attempts.map((attempt) => (
+              <tr key={attempt.id} style={{ borderTop: '1px solid var(--border-default)' }}>
+                <td className="py-2.5 pr-4">
+                  {new Date(attempt.date).toLocaleDateString(undefined, {
+                    year: 'numeric', month: 'short', day: 'numeric',
+                  })}
+                </td>
+                <td className="py-2.5 pr-4">
+                  {attempt.score}/{attempt.total} ({attempt.percentage}%)
+                </td>
+                <td className="py-2.5 pr-4">
+                  {attempt.passed ? (
+                    <span className="inline-flex items-center gap-1" style={{ color: 'var(--success-text)' }}>
+                      <CheckCircle size={16} aria-hidden="true" style={{ color: 'var(--success-icon)' }} />
+                      Pass
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1" style={{ color: 'var(--error-text)' }}>
+                      <XCircle size={16} aria-hidden="true" style={{ color: 'var(--error-icon)' }} />
+                      Fail
+                    </span>
+                  )}
+                </td>
+                <td className="py-2.5">
+                  {attempt.detail ? (
+                    <Link
+                      to={`/practice/results/${attempt.id}`}
+                      className="font-medium underline"
+                      style={{ color: 'var(--text-accent)' }}
+                    >
+                      Review
+                      <span className="sr-only">
+                        {' '}attempt from {new Date(attempt.date).toLocaleDateString()}
+                      </span>
+                    </Link>
+                  ) : (
+                    <span style={{ color: 'var(--text-muted)' }}>—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-base mt-2 mb-3" style={{ color: 'var(--text-muted)' }}>
+        Question-by-question review is kept for your most recent attempt.
+      </p>
+      {confirmingClear ? (
+        <span className="inline-flex items-center gap-2">
+          <span className="text-base font-medium" style={{ color: 'var(--error-text)' }}>
+            Delete all {courseLabel} attempts?
+          </span>
+          <button
+            onClick={() => { onClear(); setConfirmingClear(false); }}
+            className="px-3 py-1.5 rounded-lg text-base font-bold border-2"
+            style={{ borderColor: 'var(--error-border)', color: 'var(--error-text)', backgroundColor: 'var(--error-bg)' }}
+          >
+            Yes, delete
+          </button>
+          <button
+            onClick={() => setConfirmingClear(false)}
+            className="px-3 py-1.5 rounded-lg text-base font-medium border-2 hover-surface"
+            style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+          >
+            Cancel
+          </button>
+        </span>
+      ) : (
+        <button
+          onClick={() => setConfirmingClear(true)}
+          className="text-base font-medium underline"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          Clear {courseLabel} history
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/practice/SubmitConfirmDialog.jsx
+++ b/src/components/practice/SubmitConfirmDialog.jsx
@@ -1,0 +1,41 @@
+import ModalDialog from '../common/ModalDialog';
+
+export default function SubmitConfirmDialog({ isOpen, onClose, onSubmit, answeredCount, totalQuestions, flaggedCount }) {
+  const unanswered = totalQuestions - answeredCount;
+
+  return (
+    <ModalDialog isOpen={isOpen} onClose={onClose} labelledBy="submit-confirm-title">
+      <h2
+        id="submit-confirm-title"
+        className="text-xl font-bold mb-2"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        Submit test?
+      </h2>
+      <p className="text-base mb-5" style={{ color: 'var(--text-secondary)' }}>
+        You have answered {answeredCount} of {totalQuestions} questions.
+        {unanswered > 0 && ` ${unanswered} unanswered question${unanswered === 1 ? '' : 's'} will be marked incorrect.`}
+        {flaggedCount > 0 && ` You still have ${flaggedCount} question${flaggedCount === 1 ? '' : 's'} flagged for review.`}
+        {' '}This can&apos;t be undone.
+      </p>
+      <div className="flex items-center justify-end gap-3 flex-wrap">
+        {/* Safe default gets initial focus */}
+        <button
+          autoFocus
+          onClick={onClose}
+          className="px-4 py-2 rounded-xl text-base font-medium border-2 hover-surface"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+        >
+          Return to test
+        </button>
+        <button
+          onClick={onSubmit}
+          className="px-4 py-2 rounded-xl text-base font-bold"
+          style={{ backgroundColor: 'var(--btn-accent)', color: 'var(--text-on-accent)' }}
+        >
+          Submit test
+        </button>
+      </div>
+    </ModalDialog>
+  );
+}

--- a/src/components/practice/TimerBar.jsx
+++ b/src/components/practice/TimerBar.jsx
@@ -1,0 +1,94 @@
+import { useRef, useEffect } from 'react';
+import { AlertTriangle, Eye, EyeOff, TimerIcon } from 'lucide-react';
+import { useAnnounce } from '../../hooks/useAnnounce';
+import {
+  TIMER_MILESTONES_SEC,
+  ASSERTIVE_MILESTONES_SEC,
+  TIMER_WARN_THRESHOLD_SEC,
+} from '../../data/practiceConfig';
+import { formatClock, formatSpoken } from '../../utils/formatTime';
+
+/**
+ * Countdown display. The ticking clock is aria-hidden — screen reader users
+ * get milestone announcements (60/30/15/5/1 minutes) instead of a chatterbox.
+ * The visual timer can be hidden to reduce anxiety; announcements still fire.
+ */
+export default function TimerBar({ remainingSec, isRunning, hidden, onToggleHidden }) {
+  const announce = useAnnounce();
+  const announcedRef = useRef(null);
+
+  useEffect(() => {
+    // Seed on first render: milestones already passed must not replay on resume
+    if (announcedRef.current === null) {
+      announcedRef.current = new Set(TIMER_MILESTONES_SEC.filter((m) => remainingSec <= m));
+      return;
+    }
+    if (!isRunning) return;
+    for (const m of TIMER_MILESTONES_SEC) {
+      if (remainingSec <= m && !announcedRef.current.has(m)) {
+        announcedRef.current.add(m);
+        announce(
+          `${formatSpoken(m)} remaining`,
+          ASSERTIVE_MILESTONES_SEC.includes(m) ? 'assertive' : undefined
+        );
+      }
+    }
+  }, [remainingSec, isRunning, announce]);
+
+  const warn = remainingSec <= TIMER_WARN_THRESHOLD_SEC;
+
+  return (
+    <div
+      className="flex items-center justify-between gap-3 rounded-xl border-2 px-4 py-2 mb-5"
+      style={{
+        borderColor: warn && !hidden ? 'var(--warning-border)' : 'var(--border-default)',
+        backgroundColor: warn && !hidden ? 'var(--warning-bg)' : 'var(--bg-surface)',
+      }}
+    >
+      <div className="flex items-center gap-3" aria-hidden="true">
+        {!hidden ? (
+          <>
+            <TimerIcon size={18} style={{ color: warn ? 'var(--warning-text)' : 'var(--text-muted)' }} />
+            <span
+              className="font-mono text-lg font-bold"
+              style={{ color: warn ? 'var(--warning-text)' : 'var(--text-primary)' }}
+            >
+              {formatClock(remainingSec)}
+            </span>
+            {warn && (
+              <span
+                className="inline-flex items-center gap-1 text-base font-medium"
+                style={{ color: 'var(--warning-text)' }}
+              >
+                <AlertTriangle size={16} />
+                Time running low
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="text-base" style={{ color: 'var(--text-muted)' }}>
+            Timer hidden — you&apos;ll still get time warnings
+          </span>
+        )}
+      </div>
+      <button
+        onClick={onToggleHidden}
+        aria-pressed={hidden}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-base font-medium hover-surface"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        {hidden ? (
+          <>
+            <Eye size={16} aria-hidden="true" />
+            Show timer
+          </>
+        ) : (
+          <>
+            <EyeOff size={16} aria-hidden="true" />
+            Hide timer
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/data/knowledgeBase/index.js
+++ b/src/data/knowledgeBase/index.js
@@ -1,7 +1,10 @@
 /**
  * POURcast Study Shelf - Knowledge Base
- * Comprehensive CPACC exam preparation topics
+ * Comprehensive CPACC and WAS exam preparation topics
  */
+import { wasDomain1Topics } from './wasDomain1Topics';
+import { wasDomain2Topics } from './wasDomain2Topics';
+import { wasDomain3Topics } from './wasDomain3Topics';
 
 export const topics = [
   // ============================================================
@@ -2035,7 +2038,7 @@ export const topics = [
     content: [
       {
         type: 'paragraph',
-        text: 'EN 301 549 is the European standard for accessibility requirements for ICT products and services. First published in 2014, it was developed by the European Telecommunications Standards Institute (ETSI) on behalf of the European Commission. The standard is referenced by the EU Web Accessibility Directive and the European Accessibility Act. It goes beyond web content to cover software, hardware, documents, telecommunications, and support services.'
+        text: 'EN 301 549 is the European standard for accessibility requirements for ICT products and services. It is a "harmonised" European standard, developed by the three official European Standards Organisations — CEN, CENELEC, and ETSI — on an explicit demand ("Mandate") of the European Commission to support European legislation. Harmonised standards provide voluntary technical specifications for presumed conformity: using the standard is an efficient way to show compliance, but an organization is free to choose other technical solutions to fulfill its legal obligations. The standard was originally developed to support procurement of accessible ICT, and goes beyond web content to cover software, hardware, documents, telecommunications, and support services. The current version (3.2.1) was published in 2021.'
       },
       {
         type: 'heading',
@@ -2044,24 +2047,62 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'Chapter 9: Web content — directly incorporates WCAG 2.1 Level AA success criteria',
+          'Clause 4: Functional performance statements — user needs for locating, identifying, and operating ICT functions and accessing information, regardless of physical, cognitive, or sensory abilities',
+          'Chapter 9: Web content — directly references WCAG 2.1 Level A and AA success criteria (AAA criteria are referred to in 9.5, and the WCAG conformance requirements in 9.6)',
           'Chapter 10: Non-web documents — applies WCAG principles to PDFs, Word docs, and other non-web content',
           'Chapter 11: Software — applies WCAG principles to native applications and software interfaces',
           'Chapter 12: Documentation and support services — accessible user documentation, help desks, etc.',
           'Chapter 13: ICT providing relay or emergency service access',
-          'Chapter 5-8: Generic requirements, ICT with two-way voice, ICT with video, hardware'
+          'Chapter 5-8: Generic requirements, ICT with two-way voice, ICT with video, hardware',
+          'Chapters 10 and 11 draw on the non-normative W3C guidance WCAG2ICT (Applying WCAG to Non-Web ICT)'
         ]
       },
       {
         type: 'paragraph',
         text: 'EN 301 549 is particularly important because it extends WCAG beyond web content. While WCAG itself only covers web content, EN 301 549 adapts WCAG criteria for non-web documents (Chapter 10) and native software (Chapter 11). This means organizations subject to EN 301 549 must make their PDFs, mobile apps, desktop software, and hardware accessible, not just their websites.'
       },
+      {
+        type: 'heading',
+        text: 'The Annexes'
+      },
+      {
+        type: 'list',
+        items: [
+          'Annex A presents the relationship between the technical requirements and the EU Web Accessibility Directive (Directive (EU) 2016/2102), which covers public sector websites and apps. Table A.1 lists the requirements that provide presumed conformance with the Directive — including 38 additional requirements applicable to web content that go beyond the WCAG success criteria',
+          'Annex B maps the functional performance statements (user needs) of Clause 4 to the technical requirements of clauses 5-13. This makes it possible to assess the impact of specific requirements — which user groups are affected and how — and is a useful tool when judging the severity and user impact of issues',
+          'Annex C describes the test procedures and evaluation methodology for determining conformance with each requirement. It lists a test for every requirement but does not provide a detailed testing methodology'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Self-Scoping Requirements'
+      },
+      {
+        type: 'paragraph',
+        text: 'Because EN 301 549 can apply to any ICT product or service, its requirements use a feature-based, "self-scoping" approach: each requirement (except those in Chapter 12) includes applicability wording, such as "Where ICT displays video with synchronised audio, it shall have a mode of operation...". If the precondition is not met, the requirement simply does not apply; if it is met, you assess pass or fail using the corresponding Annex C test.'
+      },
+      {
+        type: 'heading',
+        text: 'Relationship to EU Legislation and Global Adoption'
+      },
+      {
+        type: 'list',
+        items: [
+          'Web Accessibility Directive (2016/2102): public sector bodies achieve presumed conformity by meeting the Annex A requirements',
+          'European Accessibility Act (EAA): EN 301 549 is being updated under Mandate 587 (together with other standards) to support the EAA, which entered into force on 28 June 2025 and extends accessibility obligations to many private-sector products and services',
+          'Adoption beyond Europe: adopted in Australia as AS EN 301 549, and also used in countries such as Canada, Mexico, and Kenya',
+          'ITI publishes a VPAT edition (VPAT 2.4 Rev EU) for reporting conformance against EN 301 549'
+        ]
+      },
     ],
-    relatedTopics: ['eu-accessibility', 'wcag-overview', 'section-508', 'vpat'],
+    relatedTopics: ['eu-accessibility', 'wcag-overview', 'section-508', 'vpat', 'wcag-conformance-requirements'],
     examTips: [
-      'European ICT standard — incorporates WCAG 2.1 AA and extends beyond web',
-      'Chapter 9 = web, Chapter 10 = documents, Chapter 11 = software',
-      'Referenced by EU Web Accessibility Directive and European Accessibility Act',
+      'European ICT standard — references WCAG 2.1 A and AA and extends beyond web',
+      'Chapter 9 = web, Chapter 10 = documents, Chapter 11 = software; Clause 4 = functional performance statements (user needs)',
+      'Annex A Table A.1 = presumed conformance with the Web Accessibility Directive, including 38 requirements beyond WCAG for web content',
+      'Annex B maps user needs to technical requirements — use it to judge user impact; Annex C provides the tests',
+      'Requirements are self-scoping ("Where ICT...") — if the precondition is absent, the requirement is not applicable',
+      'Harmonised standard = voluntary route to presumed conformity; being updated under Mandate 587 for the European Accessibility Act',
       'US Section 508 Refresh also harmonized with EN 301 549'
     ]
   },
@@ -2204,13 +2245,34 @@ export const topics = [
           'Level 5 — Optimizing/Leading: Continuous improvement, accessibility is part of organizational DNA'
         ]
       },
+      {
+        type: 'heading',
+        text: 'Procurement Maturity Models'
+      },
+      {
+        type: 'paragraph',
+        text: 'Maturity models are especially powerful within procurement processes. Applying a maturity model to procurement ensures accessibility is systematically considered in purchasing decisions, reduces the risk of acquiring inaccessible products or services, and fosters long-term, sustainable accessibility improvements across the supply chain. The WAS Body of Knowledge names two publicly available, free maturity models that specifically address procurement:'
+      },
+      {
+        type: 'list',
+        items: [
+          'PDAA (Policy Driven Adoption for Accessibility): an initiative by the National Association of State Chief Information Officers (NASCIO) that helps procurement organizations choose vendors who can meet accessibility requirements',
+          'W3C Accessibility Maturity Model — Procurement dimension: includes assessments for sourcing, negotiation, and selection of goods and services, reviewing the use of accessibility processes, criteria, contract language, and decision-making to procure and maintain accessible products and services throughout the procurement life cycle'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Maturity models can also be used to illustrate progress and sustainability to stakeholders — showing that accessibility is improving over time, not just whether a single audit passed.'
+      },
     ],
-    relatedTopics: ['w3c-wai', 'procurement-accessibility', 'vpat'],
+    relatedTopics: ['w3c-wai', 'procurement-accessibility', 'procurement-expert-role', 'vpat'],
     examTips: [
       'Maturity models = organizational capability assessment, not technical compliance',
       'Cover people, process, and technology dimensions',
       'Progress from ad-hoc/reactive to integrated/leading',
-      'W3C WAI Accessibility Maturity Model is the key reference'
+      'W3C WAI Accessibility Maturity Model is the key reference',
+      'PDAA (by NASCIO) = procurement-focused model helping organizations evaluate vendors against accessibility requirements',
+      'W3C maturity model procurement dimension: sourcing, negotiation, selection, contract language, decision-making'
     ]
   },
   {
@@ -2231,7 +2293,7 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'VPAT 2.x is the current version, available in multiple editions:',
+          'VPAT 2.4 is the version referenced in the WAS Body of Knowledge (2.5 is the latest published), available in multiple editions:',
           'WCAG Edition: Covers WCAG 2.x success criteria',
           'Section 508 Edition: Covers the Revised Section 508 Standards (for US federal procurement)',
           'EN 301 549 Edition: Covers the European ICT accessibility standard',
@@ -2249,7 +2311,7 @@ export const topics = [
           'Partially Supports: Some functionality meets the criterion',
           'Does Not Support: The majority of functionality does not meet the criterion',
           'Not Applicable: The criterion is not relevant to the product',
-          'Not Evaluated: The product has not been evaluated against this criterion'
+          'Not Evaluated: The product has not been evaluated against this criterion (a VPAT-template option permitted only for WCAG Level AAA criteria — the BoK lists just the first four levels)'
         ]
       },
     ],
@@ -3087,14 +3149,39 @@ export const topics = [
           'Whether focus is moved appropriately when new content appears'
         ]
       },
+      {
+        type: 'heading',
+        text: 'Tool Landscape by Phase'
+      },
+      {
+        type: 'paragraph',
+        text: 'The WAS Body of Knowledge groups testing tools into classes that apply at different stages of the development lifecycle. When deciding whether and when to use an automated tool, consider: which phase of the lifecycle you are testing in, whether tests will be repeated, who is conducting the test (designer, developer, content author, QA), and the tester\'s level of expertise — automated findings always need human interpretation to derive further actions.'
+      },
+      {
+        type: 'list',
+        items: [
+          'Site-wide scanning, monitoring, and reporting (production/operations): crawl entire sites and track results over time — e.g., AMP and Tenon.io (Level Access), WAVE API (WebAIM), SortSite (PowerMapper); server-based analysis like Siteimprove Accessibility and WebAIM\'s AIM Report; and open-source EU-monitoring scanners such as Access Monitor (Portugal), BOSA Accessibility Checker (Belgium), and Observatorio de Accesibilidad Web (Spain)',
+          'Browser-based developer/QA tools (development and QA, one page at a time): ANDI — Accessible Name and Description Inspector (US Social Security Administration), ARC Toolkit/ARC Platform (TPGi), Accessibility Insights (Microsoft), AInspector for Firefox (University of Illinois), axe browser extension (Deque), WAVE extension (WebAIM), Chrome Lighthouse, browser DevTools inspectors, and JavaScript bookmarklets for specific checks',
+          'Unit and integration testing APIs (during development and before deployment): axe API/axe-core (integrates with Selenium and similar frameworks) and Tenon API — run automatically in CI/CD to catch regressions before release',
+          'Guided manual testing tools (structured QA walkthroughs based on heuristics): Accessibility Insights for Web (Microsoft), ARC Platform (TPGi), Axe Auditor (Deque), JAWS Inspect (Freedom Scientific)',
+          'Simulators (design reviews and empathy-building): Color Oracle and NoCoffee simulate color vision deficiencies and low vision; PEAT (Photosensitive Epilepsy Analysis Tool, Trace R&D Center) analyzes content for seizure risks',
+          'Single-purpose tools and inspectors: WebAIM Contrast Checker, Colour Contrast Analyser (TPGi/Paciello Group), HeadingsMap, and accessibility API viewers like Accessibility Viewer (Windows) and Xcode Accessibility Inspector (macOS)'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Match the tool class to the lifecycle phase: simulators and contrast checkers during design; unit/integration APIs and browser extensions during development; guided manual and browser QA tools during testing; site-wide scanners for ongoing monitoring of released products.'
+      },
     ],
-    relatedTopics: ['testing-fundamentals', 'screen-reader-testing', 'keyboard-testing'],
+    relatedTopics: ['testing-fundamentals', 'screen-reader-testing', 'keyboard-testing', 'act-rules'],
     examTips: [
       'axe-core is the most widely used engine; Lighthouse uses it under the hood',
       'Automated tools aim for zero false positives — but that means they miss issues they cannot confirm',
       'WAVE provides visual overlays; axe provides structured results for developers',
       'Use automated tools in CI/CD to prevent regression, not as the sole testing method',
-      'Automated tools cannot judge the quality or context of accessibility implementations'
+      'Automated tools cannot judge the quality or context of accessibility implementations',
+      'Tool classes by phase: simulators (design) → unit/integration APIs (development/CI) → browser tools (page-level dev/QA) → site-wide scanners (production monitoring)',
+      'Know the named examples: ANDI, ARC Toolkit, Accessibility Insights, AInspector, axe, WAVE (browser); PEAT (photosensitivity); Color Oracle/NoCoffee (vision simulation)'
     ]
   },
   {
@@ -3753,6 +3840,10 @@ export const topics = [
         ]
       },
       {
+        type: 'paragraph',
+        text: 'The intent behind the two parts is complementary. If authoring tools take accessibility into account, more content creators — including people with disabilities — will be able to use these interfaces and produce web content (Part A). And content itself will be more accessible, because tools that follow the guidelines provide the resources needed to create accessible web content and avoid accessibility problems (Part B). ATAG 2.0 specifies requirements primarily for developers of authoring tools, but the guidelines and supporting documents also help organizations evaluate and choose software that provides an accessible interface and accessible content output.'
+      },
+      {
         type: 'heading',
         text: 'ATAG Structure'
       },
@@ -3762,7 +3853,24 @@ export const topics = [
           'Like WCAG, ATAG is organized into Principles, Guidelines, and Success Criteria at three conformance levels (A, AA, AAA)',
           'Part A principles cover: perceivable editing views, operable editing views, understandable editing views, and robust editing views',
           'Part B principles cover: automated accessible content production, assisting authors to produce accessible content, and promoting accessibility features',
-          'Implementing ATAG 2.0 is the non-normative supporting document (similar to Understanding WCAG)'
+          'ATAG 2.0 itself is the normative document — its Success Criteria are the testable requirements',
+          'Implementing ATAG 2.0 is the non-normative supporting document (similar to Understanding WCAG) — it provides guidance for understanding ATAG but is not required for conformance'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Automated Practices vs. Author Input'
+      },
+      {
+        type: 'paragraph',
+        text: 'A key WAS skill is distinguishing good practices a tool can fully automate from those that require author or user input. Some accessibility outcomes can be automated reliably: generating valid, semantic markup; providing accessible templates; preserving accessibility information (like alt text) when content is copied or transformed. Others depend on human judgment about meaning and context: only the author knows whether alt text accurately describes an image, whether a heading is descriptive, or whether a caption is correct. For these, the tool\'s job is to prompt, guide, and check — not to silently fabricate.'
+      },
+      {
+        type: 'list',
+        items: [
+          'Power of automated authoring features: they scale across all content produced with the tool, prevent entire classes of errors at the source, and help authors with no accessibility expertise produce accessible output',
+          'Limitations: automation cannot judge the appropriateness or quality of content decisions — auto-generated text alternatives or automatic "repairs" can be wrong or meaningless without author review',
+          'Well-designed tools combine both: automate what is mechanical, and prompt the author for what requires judgment (e.g., requiring alt text at upload rather than inserting a filename)'
         ]
       },
       {
@@ -3779,10 +3887,13 @@ export const topics = [
         ]
       },
     ],
-    relatedTopics: ['wcag-overview', 'w3c-wai', 'procurement-accessibility'],
+    relatedTopics: ['wcag-overview', 'w3c-wai', 'procurement-accessibility', 'normative-vs-non-normative'],
     examTips: [
       'Part A = tool UI is accessible; Part B = tool produces accessible content',
+      'Part A intent: people with disabilities can author; Part B intent: tools provide what authors need to produce accessible output',
       'ATAG is a W3C Recommendation with three conformance levels (A, AA, AAA)',
+      'ATAG 2.0 = normative; Implementing ATAG 2.0 = non-normative supporting document',
+      'Automation handles mechanics (valid markup, accessible templates); author input is needed for judgment calls (is the alt text accurate?)',
       'Three WAI guidelines: WCAG (content), ATAG (authoring tools), UAAG (user agents)',
       'ATAG currently references WCAG 2.0 — apply WCAG 2.1/2.2 criteria when evaluating',
       'Examples of authoring tools: CMS, WYSIWYG editors, social media platforms, LMS'
@@ -3913,7 +4024,26 @@ export const topics = [
     content: [
       {
         type: 'paragraph',
-        text: 'Accessibility quality assurance is most effective when integrated into every phase of the product lifecycle: Plan, Create, Test (PCT). Discovering and fixing accessibility issues early (shift-left testing) is far more cost-effective than remediating after release. Every team member — from management to designers, developers, content creators, and QA — has a role in delivering an accessible product.'
+        text: 'Accessibility quality assurance is most effective when integrated into every phase of the product lifecycle: Plan, Create, Test (PCT). Discovering and fixing accessibility issues early (shift-left testing) is far more cost-effective than remediating after release. Every team member — from management to designers, developers, content creators, and QA — has a role in delivering an accessible product. Accessibility experts and people with disabilities should be part of all stages to ensure the quality and usability of the product.'
+      },
+      {
+        type: 'heading',
+        text: 'Management and Organizational Responsibilities'
+      },
+      {
+        type: 'paragraph',
+        text: 'Management sets the conditions for a sustainable accessibility implementation. Having an accessibility expert on the team (or an external consultant) can be helpful, but the requirements must be shared across the team — every member has a role to play. W3C\'s Planning and Managing Web Accessibility guidance similarly recommends developing internal expertise and identifying accessibility champions to sustain the effort.'
+      },
+      {
+        type: 'list',
+        items: [
+          'Define accessibility goals and policies for the organization',
+          'Provide the necessary resources and budgets',
+          'Ensure know-how through training, and organize awareness events',
+          'Include accessibility in job descriptions and assign responsibilities to individuals',
+          'Sustain the effort beyond project completion: accessibility must be maintained through support, content updates, and regression testing',
+          'The full product lifecycle includes concept, requirements, design, prototyping, development, QA, user testing, support, and regression testing — each role should include some aspect of accessibility'
+        ]
       },
       {
         type: 'heading',
@@ -3966,8 +4096,10 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'Agile: accessibility is integrated into each sprint — test early and often; include a11y criteria in story acceptance requirements; iterate based on testing feedback',
-          'Waterfall: testing happens at the end of development — if issues are found late, they are more expensive and time-consuming to fix; tests may be rushed or omitted under time pressure',
+          'Agile: accessibility is integrated into each sprint — test early and often; include a11y criteria in story acceptance requirements; iterate based on testing feedback. The Plan–Create–Test cycle repeats until the task is considered complete',
+          'An agile approach to accessibility requires a fundamental understanding by all team members and acceptance of accessibility as an integral part of the workflow — everyone must understand what accessibility is, who benefits, why it matters, and how to do it',
+          'Waterfall: a linear process that breaks activities into sequential phases, each depending on the deliverables of the previous phase — testing happens at the end of development',
+          'Because projects tend to be time-pressured and over budget, end-of-process tests may be rushed, omitted, or their findings ignored; problems discovered late involve more work and cost more to fix than doing things right from the start',
           'Agile is generally more effective for accessibility because it enables early discovery and iterative improvement'
         ]
       },
@@ -3977,9 +4109,11 @@ export const topics = [
       'Plan–Create–Test cycle: accessibility is part of every phase',
       'Shift-left: find issues early when they are cheaper to fix',
       'Every team member has a role in accessibility — not just QA',
+      'Management responsibilities: define goals/policies, provide budget, ensure training, include accessibility in job descriptions',
+      'An in-team expert or consultant helps, but accessibility knowledge must be shared across the whole team',
       'Automated tools catch 30-50% of issues — manual testing always required',
       'Agile: accessibility in every sprint and Definition of Done',
-      'Waterfall: late-stage testing is risky — issues are more expensive to fix'
+      'Waterfall: linear, sequential phases with late-stage testing — issues found late are more expensive, and tests risk being rushed or omitted'
     ]
   },
 
@@ -4056,11 +4190,30 @@ export const topics = [
         type: 'list',
         items: [
           'Fixing: targeted repairs to specific issues without changing the overall design — appropriate for localized, minor defects',
-          'Redesign: rebuilding a component or page section from scratch — necessary when defects are widespread, deeply embedded in the architecture, or in templates/design systems',
-          'Hybrid approach: immediately fix critical blockers while planning a longer-term redesign for systemic issues',
-          'Consider: is the current code maintainable? Older, complex code may make fixing harder and more fragile than rewriting',
-          'A rewrite can incorporate current best practices and be more future-proof, but requires more resources'
+          'Redesign: rebuilding a component or page section from scratch — necessary when defects are widespread, deeply embedded in the architecture, or in templates/design systems'
         ]
+      },
+      {
+        type: 'heading',
+        text: 'The Five Decision Factors'
+      },
+      {
+        type: 'paragraph',
+        text: 'The WAS Body of Knowledge names five factors to evaluate when deciding whether to remediate existing code or rewrite it:'
+      },
+      {
+        type: 'list',
+        items: [
+          'Severity and scope of defects: minor, localized issues favor remediation; widespread defects affecting core functionality — especially in templates or design systems — may require a complete rewrite',
+          'Code complexity and maintainability: older, complex, poorly structured code makes remediation difficult and costly; rewriting to modern standards can yield a cleaner, more maintainable solution',
+          'User impact: prioritize the user experience — if defects significantly hinder accessibility, a more comprehensive approach (potentially a rewrite) may be warranted',
+          'Resource availability: remediation is usually quicker and cheaper; if time, budget, and expertise allow, a rewrite can produce a more robust, future-proof solution',
+          'Future-proofing: a rewrite can incorporate current and emerging best practices, making the site more adaptable to future accessibility requirements and technology changes'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'In practice, a hybrid approach is often used: immediate remediation addresses critical issues while a longer-term plan is developed for a comprehensive rewrite to ensure sustainable accessibility.'
       },
       {
         type: 'heading',
@@ -4069,9 +4222,10 @@ export const topics = [
       {
         type: 'list',
         items: [
-          'A conformance failure clearly violates a WCAG Success Criterion — it must be fixed to achieve conformance',
-          'A best practice issue makes the experience suboptimal but does not technically fail a specific SC — it should still be recommended for better usability',
+          'A conformance failure clearly violates a WCAG Success Criterion — it must be fixed to achieve conformance. A conformance test should flag a failure only when deficiencies clearly map to documented WCAG Failure techniques or otherwise clearly fail the normative success criterion, with the underlying deficiency clearly described',
+          'A best practice issue makes the experience suboptimal but does not technically fail a specific SC — it should still be recommended for better usability. A site that minimally conforms can still be difficult to use',
           'Auditors must clearly communicate the distinction: "This fails SC 1.1.1" vs. "This is a usability concern but not a WCAG failure"',
+          'Consult the WCAG supporting documents — the Understanding texts, the Techniques, and the ARIA Authoring Practices Guide (APG) — to determine whether an issue counts as a normative failure or is best-practice advice',
           'WCAG Sufficient Techniques are informative, not normative — there may be valid approaches not documented as techniques'
         ]
       },
@@ -4092,11 +4246,13 @@ export const topics = [
         ]
       },
     ],
-    relatedTopics: ['remediation-prioritization', 'semantic-html', 'aria-overview', 'form-accessibility', 'color-contrast'],
+    relatedTopics: ['remediation-prioritization', 'semantic-html', 'aria-overview', 'form-accessibility', 'color-contrast', 'failures-vs-best-practices', 'stakeholder-communication'],
     examTips: [
       'Conformance failure = violates a WCAG SC; best practice = improves UX but not a formal failure',
       'ARIA patches can fix issues without redesign, but semantic HTML is preferred long-term',
-      'Hybrid approach: fix critical blockers immediately, plan redesign for systemic issues',
+      'Hybrid approach: remediate critical issues now while planning a longer-term comprehensive rewrite',
+      'Five fix-vs-redesign factors: severity/scope, code complexity & maintainability, user impact, resource availability, future-proofing',
+      'Use Understanding docs, Techniques, and the APG to distinguish true failures from best-practice advice',
       'Communicate clearly: which SC fails, where on the page, and how to fix it',
       'Sufficient Techniques are informative, not normative — other valid approaches exist',
       'Consider code complexity and maintainability when choosing fix vs. redesign'
@@ -4119,6 +4275,18 @@ export const topics = [
       },
       {
         type: 'heading',
+        text: 'Adaptive Strategies vs. Assistive Technologies'
+      },
+      {
+        type: 'list',
+        items: [
+          'Adaptive strategies: configuring standard software and hardware to a person\'s needs — increasing text size, changing text and background colors, reducing mouse speed, turning on captions. Standard hardware, mobile devices, operating systems, and browsers all have built-in accessibility features',
+          'Assistive technologies: dedicated software or hardware such as screen readers, magnification software, or alternative input devices like switches and voice input',
+          'Coping strategies and preferred methods: users develop their own well-practiced ways of working and generally rely on their preferred, familiar methods (their own AT, settings, and navigation habits) rather than learning website-specific mechanisms — so content should work with users\' standard tools and configurations instead of forcing per-site workarounds'
+        ]
+      },
+      {
+        type: 'heading',
         text: 'Users Without Vision (Blind)'
       },
       {
@@ -4127,9 +4295,28 @@ export const topics = [
           'Primary AT: screen readers (JAWS, NVDA on Windows; VoiceOver on macOS/iOS; TalkBack on Android)',
           'Navigation strategies: jump by headings, landmarks, links, form controls, or tables using screen reader keyboard shortcuts',
           'Screen readers present content linearly following DOM order — visual layout is irrelevant',
-          'Modes: Browse/Read mode (navigate by element), Forms mode (type in form fields), Application mode (widget keyboard patterns)',
-          'Mobile: completely different gesture-based interaction model — swipe right/left to move forward/back, double-tap to activate',
-          'Refreshable Braille displays may be used for reading output instead of or alongside speech'
+          'Modes: Browse/Read mode (navigate by element), Forms mode (type in form fields), Application mode (widget keyboard patterns); VoiceOver offers the rotor and TalkBack a comparable menu for choosing navigation granularity',
+          'Refreshable Braille displays — external devices made up of rows of pins that raise and lower to form Braille characters — may be used for reading output instead of or alongside speech',
+          'Deaf-blind users depend on refreshable Braille displays: speech output is unusable for them, so Braille is their primary (often only) channel for screen reader output',
+          'Many screen reader users also use voice input — repetitive-strain conditions like carpal tunnel are common, and speaking is often quicker than virtual keyboard input'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Touch Interaction with a Screen Reader Running'
+      },
+      {
+        type: 'paragraph',
+        text: 'The interaction model for blind touchscreen users is completely different from that of sighted touchscreen users. When a screen reader (VoiceOver on iOS, TalkBack on Android) is activated, it overrides the visual touch interaction method and replaces it with a gesture-based system. Sighted users activate items based on their position on screen; screen reader users navigate sequentially and activate whatever currently has the screen reader focus.'
+      },
+      {
+        type: 'list',
+        items: [
+          'Swipe right: move forward to the next item; swipe left: move backward to the previous item',
+          'Double-tap anywhere on the screen: activate the current button or link — position no longer matters',
+          'Explore by touch: dragging a finger across the screen reads whatever is under it, letting users build a spatial picture of the layout',
+          'The specific gestures vary from one screen reader brand to the next',
+          'Design implication: hover-dependent and position-dependent interactions break under this model — for example, a menu item that opens a submenu on hover and follows a link on click is problematic for gesture-based mobile screen reader users'
         ]
       },
       {
@@ -4160,6 +4347,21 @@ export const topics = [
           'Head pointers, mouth sticks, eye trackers: need large click targets and adequate spacing between targets',
           'Skip navigation links are critical since keyboard-only users cannot navigate by headings or landmarks',
           'Prediction and autofill reduce the number of keystrokes needed for text input'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Users with Limited Reading Capacity'
+      },
+      {
+        type: 'list',
+        items: [
+          'A wide spectrum of people have reading difficulties, including (but not limited to) people with ADHD, dyslexia, Irlen syndrome, or memory loss',
+          'Some use literacy-support assistive technology such as Kurzweil, read&write or BrowseAloud (Texthelp), NaturalReader, or platform text-to-speech — and some use no assistive technology at all',
+          'Text-to-speech (TTS) software highlights and reads text aloud so users can see and hear it simultaneously, freeing energy for comprehending rather than decoding words. Unlike screen readers, TTS focuses on text content and does not convey semantic information or navigation hints — most users in this group do not need that level of support',
+          'Some users prefer non-text formats — audio, video, or slide-based presentations with visual content — wherever available',
+          'Users may change text size, text and background colors, font, spacing, and line width in the browser, or apply a custom stylesheet — so text must be real text, not images of text, or these adaptations (and AT) cannot act on it',
+          'Structured section headings and semantic markup help these users navigate through content'
         ]
       },
       {
@@ -4195,12 +4397,17 @@ export const topics = [
     ],
     relatedTopics: ['screen-readers', 'switch-devices', 'visual-disabilities', 'cognitive-disabilities', 'mobility-disabilities', 'auditory-disabilities'],
     examTips: [
+      'Adaptive strategies = configuring standard software/hardware (text size, colors, mouse speed, captions); assistive technologies = dedicated tools (screen readers, magnifiers, switches)',
       'Blind: screen readers, navigate by headings/landmarks/links, content is linear per DOM order',
+      'Touch + screen reader: gestures replace visual touch — swipe right/left to move forward/back, double-tap anywhere to activate; gestures vary by screen reader',
+      'Deaf-blind users rely on refreshable Braille displays — pins that raise/lower to form Braille characters',
       'Low vision: magnification + possibly screen reader, zoom out/in for orientation, need focus tracking',
+      'Limited reading capacity: TTS reads text aloud but gives no semantic/navigation info (unlike a screen reader); real text (not images of text) is essential for adaptation',
       'Motor: keyboard-only users Tab sequentially — cannot jump by headings like SR users; voice control needs matching labels',
       'Cognitive: simple language, consistent navigation, text-to-speech (not full SR), autocomplete for forms',
       'Deaf: captions, transcripts, sign language videos; closed captions preferred over open; fix auto-caption errors',
-      'Screen reader modes: Browse/Read mode, Forms mode, Application mode'
+      'Screen reader modes: Browse/Read mode, Forms mode, Application mode (plus VoiceOver rotor / TalkBack menu)',
+      'Users rely on their own preferred, familiar methods — support standard tools and settings rather than website-specific mechanisms'
     ]
   },
 
@@ -4464,7 +4671,14 @@ export const topics = [
       'Eliminating two wrong options doubles your odds on a four-choice question',
       'Changing an answer with a reason is right more often than wrong — ignore the "first instinct" myth'
     ]
-  }
+  },
+
+  // ============================================================
+  // WAS BODY OF KNOWLEDGE GAP-FILL TOPICS (authored per domain)
+  // ============================================================
+  ...wasDomain1Topics,
+  ...wasDomain2Topics,
+  ...wasDomain3Topics
 ];
 
 // ============================================================

--- a/src/data/knowledgeBase/wasDomain1Topics.js
+++ b/src/data/knowledgeBase/wasDomain1Topics.js
@@ -1,0 +1,306 @@
+/**
+ * WAS BoK Domain One gap-fill topics — Creating Accessible Web Solutions.
+ * Spread into the main `topics` array in index.js.
+ */
+export const wasDomain1Topics = [
+  {
+    slug: 'wcag-22-new-criteria',
+    title: 'WCAG 2.2: What\'s New',
+    category: 'WCAG & Web Accessibility',
+    applicableTo: ['was'],
+    summary: 'WCAG 2.2 (October 2023) added nine new success criteria — six at A/AA — with a strong emphasis on cognitive disabilities, low vision, and motor impairments, and removed 4.1.1 Parsing.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'WCAG 2.2 became a W3C Recommendation in October 2023. It is backwards compatible with WCAG 2.0 and 2.1: content that conforms to 2.2 also conforms to the earlier versions, and 2.0 and 2.1 remain valid W3C Recommendations that laws may still reference. WCAG 2.2 adds nine new success criteria (two at Level A, four at Level AA, three at Level AAA) and removes one — 4.1.1 Parsing.'
+      },
+      {
+        type: 'heading',
+        text: 'New Focus-Related Criteria (Guideline 2.4)'
+      },
+      {
+        type: 'list',
+        items: [
+          '2.4.11 Focus Not Obscured (Minimum) (AA): when a component receives keyboard focus, it is not ENTIRELY hidden by author-created content such as sticky headers, sticky footers, or cookie banners. Partial obscuring is allowed at this level.',
+          '2.4.12 Focus Not Obscured (Enhanced) (AAA): stricter version — NO part of the focused component may be hidden by author-created content.',
+          '2.4.13 Focus Appearance (AAA): the focus indicator must be large enough (an area at least as large as a 2 CSS pixel thick perimeter of the component) and have at least 3:1 contrast between its focused and unfocused states.'
+        ]
+      },
+      {
+        type: 'paragraph',
+        text: 'These three criteria primarily benefit sighted keyboard users and people with low vision or attention limitations who need to be able to see where keyboard focus is at all times. Note the level split: only the Minimum version of Focus Not Obscured is Level AA; Focus Appearance is AAA in the final 2.2 Recommendation.'
+      },
+      {
+        type: 'heading',
+        text: 'New Input Modality Criteria (Guideline 2.5)'
+      },
+      {
+        type: 'list',
+        items: [
+          '2.5.7 Dragging Movements (AA): any functionality that uses a dragging movement (e.g., sliders, drag-and-drop reordering, map panning) must be achievable with a single pointer WITHOUT dragging (e.g., click-to-select then click-to-place buttons), unless dragging is essential or determined by the user agent. Benefits people with motor impairments who can click but cannot perform precise press-hold-move-release sequences.',
+          '2.5.8 Target Size (Minimum) (AA): pointer targets must be at least 24 by 24 CSS pixels, with exceptions for spacing (an undersized target is fine if a 24px circle centered on it does not intersect other targets), equivalent controls elsewhere on the page, inline targets within sentences, user-agent-determined sizes, and essential presentations. This is a less strict floor than the AAA criterion 2.5.5 Target Size (Enhanced), which requires 44 by 44.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'New Cognitive-Focused Criteria (Guidelines 3.2 and 3.3)'
+      },
+      {
+        type: 'paragraph',
+        text: 'The biggest theme of WCAG 2.2 is reducing cognitive load. Three of the new criteria — Consistent Help, Redundant Entry, and Accessible Authentication — were driven largely by the needs of people with cognitive and learning disabilities, including memory limitations.'
+      },
+      {
+        type: 'list',
+        items: [
+          '3.2.6 Consistent Help (A): if help mechanisms (human contact details, a human contact mechanism, a self-help option, or a fully automated contact mechanism) are provided across a set of pages, they appear in the same relative order on each page, so users can find help where they expect it.',
+          '3.3.7 Redundant Entry (A): information the user has already entered in the same process must be auto-populated or available for the user to select, rather than retyped — except when re-entering is essential, required for security (like passwords), or the previous information is no longer valid.',
+          '3.3.8 Accessible Authentication (Minimum) (AA): no step of authentication may require a cognitive function test (memorizing a password, transcribing characters, solving a puzzle) unless an alternative method that does not rely on a cognitive function test exists (e.g., WebAuthn/passkeys), a mechanism is available to assist (e.g., allowing paste so password managers work), or the test is object recognition or identifying personal content the user provided.',
+          '3.3.9 Accessible Authentication (Enhanced) (AAA): the same requirement WITHOUT the object recognition and personal-content exceptions.'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Blocking paste in a password field is a classic 3.3.8 failure scenario: it defeats password managers and forces memorization or transcription, which are cognitive function tests.'
+      },
+      {
+        type: 'heading',
+        text: 'Removed: 4.1.1 Parsing'
+      },
+      {
+        type: 'paragraph',
+        text: 'WCAG 2.2 removed SC 4.1.1 Parsing entirely. It was originally written for an era when assistive technologies parsed HTML directly; modern browsers expose a repaired, consistent DOM to AT, so the criterion no longer provided unique benefit. Issues it used to catch (like duplicate IDs breaking label associations) are still failures under other criteria such as 1.3.1 Info and Relationships and 4.1.2 Name, Role, Value. In WCAG 2.1, 4.1.1 is now noted as always satisfied for HTML content.'
+      },
+    ],
+    relatedTopics: ['wcag-overview', 'wcag-operable', 'wcag-understandable', 'focus-indicators', 'cognitive-disabilities', 'wcag-conformance-requirements'],
+    examTips: [
+      'Memorize the levels: A = Consistent Help (3.2.6) and Redundant Entry (3.3.7); AA = Focus Not Obscured Minimum (2.4.11), Dragging Movements (2.5.7), Target Size Minimum (2.5.8), Accessible Authentication Minimum (3.3.8); AAA = Focus Not Obscured Enhanced (2.4.12), Focus Appearance (2.4.13), Accessible Authentication Enhanced (3.3.9)',
+      'Target size: 24x24 px is the new AA minimum (2.5.8); 44x44 px is the older AAA enhanced requirement (2.5.5) — do not mix them up',
+      'Minimum vs Enhanced pattern: "Minimum" versions allow exceptions (partial obscuring, object recognition); "Enhanced" AAA versions remove them',
+      '4.1.1 Parsing was REMOVED in 2.2 — if an exam question asks which SC no longer exists, that is the answer',
+      'WCAG 2.2 = W3C Recommendation October 2023; 2.0 and 2.1 are still valid standards that regulations may reference'
+    ]
+  },
+  {
+    slug: 'normative-vs-non-normative',
+    title: 'Normative vs. Non-Normative: Standards and Techniques',
+    category: 'Standards & Guidelines',
+    applicableTo: ['was'],
+    summary: 'Only the WCAG success criteria themselves are normative (required for conformance); Understanding documents and Techniques are informative guidance, and specific techniques are never mandatory.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'In standards language, "normative" means a part of a document that is required for conformance — it defines what you MUST do. "Non-normative" (also called "informative") content is explanatory: it helps you understand and implement the standard but is never itself required. Knowing which W3C documents are which is heavily tested, because it determines what an auditor can actually cite as a failure.'
+      },
+      {
+        type: 'heading',
+        text: 'What Is Normative in WCAG'
+      },
+      {
+        type: 'list',
+        items: [
+          'The WCAG success criteria text, the conformance requirements, and the glossary definitions they rely on are normative.',
+          'The Understanding WCAG documents (intent, benefits, examples for each SC) are informative — useful for interpretation, not required.',
+          'The Techniques for WCAG documents are informative — they describe POSSIBLE ways to meet success criteria.',
+          'The principle and guideline statements themselves are organizational; conformance is evaluated only against success criteria.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'The Three Types of Techniques'
+      },
+      {
+        type: 'list',
+        items: [
+          'Sufficient techniques: documented, W3C-vetted ways that are sufficient to meet a success criterion — if you implement one correctly, you satisfy the SC.',
+          'Advisory techniques: go beyond what the success criteria require. They improve accessibility but were not assigned as sufficient — often because they are not testable or not sufficient on their own.',
+          'Failure techniques: documented patterns known to VIOLATE a success criterion. If content matches a documented failure, it does not conform (unless an alternative version is provided).'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Techniques are not required. The W3C states explicitly that the only thing that matters for conformance is satisfying the success criteria — authors are free to use new, custom, or undocumented methods, as long as the result meets the normative SC text.'
+      },
+      {
+        type: 'paragraph',
+        text: 'Published techniques have been vetted by a group of accessibility professionals through the W3C process, but the process of updating or retiring techniques is slow: some techniques now appear dated or even irrelevant, and solutions described in some sufficient techniques may now be considered insufficient because better implementations have become available over time. The list is also not exhaustive — technology evolves faster than the documentation, so the absence of a documented technique never means a method is invalid. Either way, an auditor should cite the success criterion, not a missing technique, when reporting an issue.'
+      },
+      {
+        type: 'heading',
+        text: 'ARIA: Spec vs. Practices'
+      },
+      {
+        type: 'list',
+        items: [
+          'The WAI-ARIA specification itself is normative: it defines the roles, states, and properties, and rules like which attributes are allowed on which roles.',
+          'The ARIA Authoring Practices Guide (APG) is informative: it provides recommended keyboard interaction and widget patterns (tabs, comboboxes, dialogs), but following APG is not itself a conformance requirement.',
+          '"Using ARIA" (the W3C document with the five rules of ARIA) is also informative guidance.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'ATAG'
+      },
+      {
+        type: 'paragraph',
+        text: 'The Authoring Tool Accessibility Guidelines (ATAG 2.0) follow the same pattern: the guidelines and success criteria in Part A (the authoring tool UI must be accessible) and Part B (the tool must support producing accessible content) are normative for ATAG conformance, while the Implementing ATAG 2.0 resource is informative.'
+      },
+      {
+        type: 'callout',
+        text: 'Exam trap: a page that fails to use any documented sufficient technique may still conform, but a page matching a documented failure technique does NOT conform to that SC.'
+      },
+    ],
+    relatedTopics: ['wcag-overview', 'wcag-conformance-requirements', 'aria-overview', 'atag-overview', 'failures-vs-best-practices', 'accessibility-supported'],
+    examTips: [
+      'Normative = required for conformance. In WCAG, only the SC text, conformance requirements, and glossary are normative',
+      'Understanding docs and Techniques are informative — implementing a sufficient technique satisfies an SC, but no technique is ever mandatory',
+      'Three technique types: Sufficient (meets the SC), Advisory (beyond requirements), Failure (documented violation)',
+      'ARIA spec = normative; ARIA Authoring Practices Guide (APG) and "Using ARIA" = informative',
+      'When citing issues, reference the success criterion, not a missing technique'
+    ]
+  },
+  {
+    slug: 'accessibility-supported',
+    title: 'Accessibility-Supported Technologies',
+    category: 'Standards & Guidelines',
+    applicableTo: ['was'],
+    summary: 'WCAG conformance requirement 4 says only accessibility-supported ways of using technologies can be relied upon — a method counts only if it actually works in users\' assistive technologies and browsers.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'WCAG conformance requirement 4 states that only "accessibility-supported" ways of using technologies can be relied upon to satisfy success criteria. A web technology (or a feature of it, like a specific ARIA attribute) is accessibility supported when it works with users\' assistive technologies AND with the accessibility features of browsers and other user agents. In other words: it is not enough that a technique is valid per the spec — it must actually function for real users with real AT.'
+      },
+      {
+        type: 'heading',
+        text: 'Why This Requirement Exists'
+      },
+      {
+        type: 'paragraph',
+        text: 'A developer could write perfectly spec-compliant code using a brand-new ARIA attribute or HTML element that no screen reader yet exposes. The page would look conformant on paper while being broken in practice. Conformance requirement 4 closes that gap: if a technology is used in a way that is NOT accessibility supported, it cannot be relied upon for conformance — though it may still be used. Conformance requirement 4 itself requires that any information or functionality provided in a non-supported way also be available in an accessibility-supported way, and conformance requirement 5 separately requires that the unsupported content not interfere with the rest of the page.'
+      },
+      {
+        type: 'heading',
+        text: 'Support Varies by Browser + AT Pairing'
+      },
+      {
+        type: 'list',
+        items: [
+          'Assistive technology support is not uniform: a feature may work in NVDA with Chrome but fail in VoiceOver with Safari, or behave differently in JAWS with Edge.',
+          'Screen readers interpret the accessibility tree differently and update on different release cycles — newer ARIA attributes often lag years behind the spec.',
+          'Mobile pairings (VoiceOver + iOS Safari, TalkBack + Android Chrome) have their own distinct support profiles.',
+          'WCAG deliberately does NOT define how many or which AT/browser combinations must support a feature — that judgment is left to authors, policies, and the environments their audiences actually use.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'How to Check Support'
+      },
+      {
+        type: 'list',
+        items: [
+          'Test directly in real browser + AT combinations relevant to your audience (e.g., NVDA + Chrome, JAWS + Edge, VoiceOver + Safari, TalkBack + Chrome).',
+          'Consult community-maintained support databases such as a11ysupport.io, which document how HTML and ARIA features behave across screen reader and browser pairings.',
+          'Check screen reader vendor release notes and caniuse-style resources for the underlying platform feature.',
+          'Treat support data as a snapshot — re-verify when browsers, AT, or your own audience profile changes.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Implications for Development'
+      },
+      {
+        type: 'list',
+        items: [
+          'Prefer long-supported, well-established techniques (native HTML elements, core ARIA roles/states) over cutting-edge features for anything users must rely on.',
+          'When adopting a new web platform or ARIA feature, verify AT support FIRST — being in the spec is not evidence of support.',
+          'Provide fallbacks when support is incomplete: e.g., pair a newer mechanism with established markup, or expose the same information through a second, well-supported route.',
+          'Document the browser/AT combinations you tested in your conformance claims and audit reports.'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Memory hook: "valid code" answers spec questions; "accessibility supported" answers the question users actually care about — does it work in my screen reader and browser?'
+      },
+    ],
+    relatedTopics: ['wcag-conformance-requirements', 'browser-at-interoperability', 'normative-vs-non-normative', 'screen-reader-testing', 'screen-readers', 'accessibility-tree'],
+    examTips: [
+      'Conformance requirement 4: only accessibility-supported ways of using technologies can be RELIED UPON to satisfy success criteria',
+      '"Accessibility supported" = works with users\' assistive technologies and with browsers\' accessibility features — support varies per browser + AT pairing',
+      'WCAG does not specify how many AT/browser combinations are needed for something to count as supported',
+      'Unsupported technologies may still be present, provided conforming alternatives exist and the unsupported content does not interfere',
+      'a11ysupport.io and direct testing in real AT are the practical ways to verify support before relying on a technique'
+    ]
+  },
+  {
+    slug: 'focus-management-patterns',
+    title: 'Focus Management Patterns: Roving tabindex & aria-activedescendant',
+    category: 'ARIA & Semantics',
+    applicableTo: ['was'],
+    summary: 'Composite widgets present one Tab stop and use arrow keys internally, implemented either by moving real DOM focus with a roving tabindex or by keeping focus on a container and pointing aria-activedescendant at the active item.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Composite widgets — tab lists, listboxes, menus, radio groups, grids, trees, toolbars — should occupy a SINGLE stop in the page Tab sequence. Once focus is inside the widget, arrow keys move between the items. If every item in a 50-option listbox were its own Tab stop, keyboard users would need 50 presses just to get past it. There are two standard mechanisms for managing which item is "active" inside the widget: roving tabindex and aria-activedescendant.'
+      },
+      {
+        type: 'heading',
+        text: 'Roving tabindex'
+      },
+      {
+        type: 'list',
+        items: [
+          'Exactly one item in the widget has tabindex="0" (the currently active item); every other item has tabindex="-1".',
+          'When the user presses an arrow key, the script sets the previous item to tabindex="-1", sets the new item to tabindex="0", and calls .focus() on it — real DOM focus MOVES to the new item.',
+          'When the user Tabs away and later Tabs back, focus returns to the item that last held tabindex="0", preserving their position.',
+          'Because actual focus is on the item, the browser fires real focus events, :focus CSS styling applies natively, and screen readers announce the newly focused element automatically.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'aria-activedescendant'
+      },
+      {
+        type: 'list',
+        items: [
+          'DOM focus stays on the widget container (or an associated input), which has tabindex="0" or is natively focusable.',
+          'The container carries aria-activedescendant="id-of-active-option"; arrow keys update this attribute value instead of moving focus.',
+          'Each option needs a unique id, an appropriate role (e.g., option in a listbox), and the active one is typically also marked with aria-selected or a highlight class.',
+          'Screen readers announce the element referenced by aria-activedescendant as if it were focused, even though document.activeElement never changes.'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'When Each Pattern Is Required'
+      },
+      {
+        type: 'paragraph',
+        text: 'For most composite widgets the two approaches are interchangeable, and roving tabindex is the simpler, more robust default. But an editable combobox (a text input with a filtering dropdown list) MUST use aria-activedescendant: the user has to keep typing, so DOM focus must remain in the text input while arrow keys highlight options in the popup list. Moving real focus into the list would pull the user out of the input and break typing. aria-activedescendant is also convenient when moving focus would cause unwanted side effects such as scroll jumps or expensive re-renders in virtualized lists.'
+      },
+      {
+        type: 'heading',
+        text: 'Common Pitfalls'
+      },
+      {
+        type: 'list',
+        items: [
+          'Forgetting to scroll the active item into view: with aria-activedescendant, focus never moves, so the browser does not auto-scroll — the script must call scrollIntoView() (and with roving tabindex, custom scroll containers can have the same issue).',
+          'No visible focus styling on the active descendant: :focus never matches the option (focus is on the container), so authors must style the active item explicitly (e.g., via [aria-selected="true"] or a class) to satisfy SC 2.4.7 Focus Visible.',
+          'Leaving multiple items with tabindex="0" in a roving pattern, creating several Tab stops inside the widget.',
+          'Pointing aria-activedescendant at an id that does not exist, or at an element that is not an owned descendant of the container.',
+          'Implementing arrow-key movement but forgetting Home/End (first/last item) and, for listboxes, type-ahead — recommended behaviors in the ARIA Authoring Practices.'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Quick test: press Tab — the whole widget should be ONE stop. Then press arrows — the highlight should move, stay visible, and stay scrolled into view, whether or not document.activeElement changes.'
+      },
+    ],
+    relatedTopics: ['aria-widget-patterns', 'standard-vs-custom-controls', 'keyboard-testing', 'focus-indicators', 'aria-states-properties', 'screen-reader-modes'],
+    examTips: [
+      'Composite widgets = one Tab stop; arrow keys navigate inside (APG keyboard model)',
+      'Roving tabindex: active item tabindex="0", others tabindex="-1", real focus moves on arrow keys',
+      'aria-activedescendant: focus stays on the container; the attribute\'s id value identifies the active option',
+      'Editable comboboxes must use aria-activedescendant because DOM focus has to stay in the text input while arrowing through options',
+      'Two classic bugs: active item not scrolled into view, and no visible highlight on the active descendant (fails 2.4.7 Focus Visible)'
+    ]
+  },
+];

--- a/src/data/knowledgeBase/wasDomain2Topics.js
+++ b/src/data/knowledgeBase/wasDomain2Topics.js
@@ -1,0 +1,554 @@
+/**
+ * WAS BoK Domain Two gap-fill topics — Identifying Accessibility Issues.
+ * Spread into the main `topics` array in index.js.
+ */
+export const wasDomain2Topics = [
+  {
+    slug: 'wcag-conformance-requirements',
+    title: 'The Five WCAG Conformance Requirements',
+    category: 'Standards & Guidelines',
+    applicableTo: ['was'],
+    summary: 'Beyond satisfying individual Success Criteria, a WCAG conformance claim must meet five normative conformance requirements: conformance level, full pages, complete processes, accessibility-supported technologies, and non-interference.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Satisfying Success Criteria is only part of WCAG conformance. The Conformance section of WCAG 2.x defines five normative requirements that a page must meet before any conformance claim can be made. Auditors need these requirements to decide whether a page, a process, or a set of pages can legitimately claim Level A, AA, or AAA conformance.'
+      },
+      {
+        type: 'heading',
+        text: '1. Conformance Level'
+      },
+      {
+        type: 'paragraph',
+        text: 'For Level A conformance, the page satisfies all Level A Success Criteria — or a conforming alternate version is provided. Level AA requires all A and AA criteria; Level AAA requires all A, AA, and AAA criteria. Conformance is cumulative: you cannot claim AA while failing an A criterion.'
+      },
+      {
+        type: 'list',
+        items: [
+          'A conforming alternate version must provide all of the same information and functionality in the same human language',
+          'It must be as up to date as the non-conforming version',
+          'It must itself conform at the claimed level',
+          'It must be reachable from the non-conforming page via an accessibility-supported mechanism (e.g., a link the user can actually perceive and operate), or the non-conforming version must only be reachable from the conforming one'
+        ]
+      },
+      {
+        type: 'heading',
+        text: '2. Full Pages'
+      },
+      {
+        type: 'paragraph',
+        text: 'Conformance and conformance level apply to full web pages only. You cannot exclude a part of the page — a single inaccessible widget, advertisement, or embedded video player means the whole page does not conform. Alternatives provided on the page (such as a transcript) count as part of the page when evaluating it.'
+      },
+      {
+        type: 'heading',
+        text: '3. Complete Processes'
+      },
+      {
+        type: 'paragraph',
+        text: 'When a page is one step in a process — a series of steps needed to accomplish an activity, like a checkout flow (product page, cart, shipping, payment, confirmation) — every page in the process must conform at the claimed level or better. If the payment step fails, no page in the checkout process can claim conformance, even pages that individually pass.'
+      },
+      {
+        type: 'heading',
+        text: '4. Only Accessibility-Supported Ways of Using Technologies'
+      },
+      {
+        type: 'paragraph',
+        text: 'Only accessibility-supported ways of using technologies may be relied upon to satisfy Success Criteria. A technology is accessibility supported when it works with users\' assistive technologies and with the accessibility features of browsers. Technologies that are not accessibility supported can still be used — they just cannot be relied upon for conformance, and conforming alternatives must carry the load.'
+      },
+      {
+        type: 'heading',
+        text: '5. Non-Interference'
+      },
+      {
+        type: 'paragraph',
+        text: 'Technologies that are NOT relied upon must not block users from accessing the rest of the page. Even content you are not counting toward conformance must not trap focus, flash dangerously, or drown out the accessible content. Four Success Criteria apply to ALL content on the page, including content not otherwise relied upon, because failing them interferes with any use of the whole page.'
+      },
+      {
+        type: 'list',
+        items: [
+          'SC 1.4.2 Audio Control — auto-playing audio longer than 3 seconds must be pausable/stoppable or have independent volume control',
+          'SC 2.1.2 No Keyboard Trap — no component may trap keyboard focus',
+          'SC 2.3.1 Three Flashes or Below Threshold — nothing may flash more than three times per second above thresholds',
+          'SC 2.2.2 Pause, Stop, Hide — moving, blinking, or auto-updating content must be controllable'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Memorize the non-interference set: 1.4.2, 2.1.2, 2.3.1, and 2.2.2 apply to every piece of content on a page — even third-party widgets and content explicitly excluded from a conformance claim.'
+      }
+    ],
+    relatedTopics: ['wcag-overview', 'wcag-em', 'accessibility-supported', 'normative-vs-non-normative'],
+    examTips: [
+      'The five requirements: Conformance Level, Full Pages, Complete Processes, Only Accessibility-Supported Ways of Using Technologies, Non-Interference',
+      'Conformance is all-or-nothing per page — no partial-page conformance, and one failing SC fails the page',
+      'A conforming alternate version must be equivalent, up to date, itself conforming, and reachable via an accessibility-supported mechanism',
+      'Complete Processes: one non-conforming step disqualifies every page in the workflow',
+      'Non-interference SCs (1.4.2, 2.1.2, 2.3.1, 2.2.2) apply to ALL page content, even content not relied upon'
+    ]
+  },
+  {
+    slug: 'browser-at-interoperability',
+    title: 'Browser + Assistive Technology Interoperability',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'Accessibility behavior depends on the specific browser and assistive technology pairing, so testers must use recommended combinations and triage whether a defect is an authoring bug, a browser bug, or an AT bug.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Assistive technologies do not read your HTML directly. The browser parses the markup, builds an accessibility tree, and exposes it through a platform accessibility API (such as UI Automation or IAccessible2 on Windows, NSAccessibility on macOS). The screen reader then interprets what the API exposes. Because each browser maps markup to the API slightly differently, and each AT interprets the API slightly differently, the same page can behave differently in different browser + AT pairings.'
+      },
+      {
+        type: 'heading',
+        text: 'Why Results Differ Across Pairings'
+      },
+      {
+        type: 'list',
+        items: [
+          'Browsers build and expose their accessibility trees differently — an ARIA attribute may be mapped fully in one browser and partially in another',
+          'Screen readers apply their own heuristics on top of the API — repairing missing names, deciding what to announce and when',
+          'Support for newer ARIA features lands at different times in different browsers and ATs',
+          'Each AT is optimized for, and primarily tested against, particular browsers'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Recommended Testing Combinations'
+      },
+      {
+        type: 'list',
+        items: [
+          'JAWS + Chrome (Windows) — the most-used commercial screen reader with the most-used browser',
+          'NVDA + Firefox or Chrome (Windows) — NVDA has long had excellent Firefox support and strong Chrome support',
+          'Narrator + Edge (Windows) — Microsoft develops and tests these together',
+          'VoiceOver + Safari (macOS and iOS) — Apple builds and tests them as a pair',
+          'TalkBack + Chrome (Android) — Google\'s screen reader with Google\'s browser'
+        ]
+      },
+      {
+        type: 'paragraph',
+        text: 'Pairing matters because mismatched combinations (e.g., VoiceOver with Chrome, or JAWS with Safari) are less thoroughly tested by vendors and produce misleading results. Test plans should cover the combinations your users actually use — WebAIM\'s screen reader surveys are a common source for usage data — rather than relying on a single pairing.'
+      },
+      {
+        type: 'heading',
+        text: 'Triaging a Pairing-Specific Bug'
+      },
+      {
+        type: 'paragraph',
+        text: 'When a defect appears in one pairing but not another, it may be an authoring bug, a browser bug, or an AT bug. Reproduce the issue across multiple pairings before assigning blame. If the markup is correct per the HTML and ARIA specifications and the issue appears in only one pairing, it is likely a browser or AT defect — which may belong in the vendor\'s bug tracker rather than the development backlog.'
+      },
+      {
+        type: 'list',
+        items: [
+          'Fails in all pairings → almost certainly an authoring (code) bug',
+          'Fails in one browser across multiple ATs → likely a browser accessibility-API mapping bug',
+          'Fails with one AT across multiple browsers → likely an AT bug',
+          'Verify the markup against the specs first — incorrect ARIA often "works" in one forgiving pairing and breaks in stricter ones'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'Avoid "coding to the screen reader" — hacking markup until one specific AT sounds right often breaks other pairings. Write spec-correct code, then report genuine AT/browser bugs upstream.'
+      }
+    ],
+    relatedTopics: ['screen-readers', 'accessibility-tree', 'screen-reader-testing', 'screen-reader-modes'],
+    examTips: [
+      'AT reads the accessibility tree via platform accessibility APIs — not your raw HTML',
+      'Recommended pairs: JAWS+Chrome, NVDA+Firefox/Chrome, Narrator+Edge, VoiceOver+Safari, TalkBack+Chrome',
+      'Test the most-used combinations for your audience, not just one pairing',
+      'Bug in only one pairing with spec-correct markup → suspect a browser or AT bug, not the code',
+      'Bug in every pairing → suspect the authoring (your code)'
+    ]
+  },
+  {
+    slug: 'testing-by-disability',
+    title: 'Testing Methodology by Disability Type',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'A systematic audit organizes test cases by the user group affected — screen reader users, keyboard and alternative input users, deaf and hard-of-hearing users, low vision users, cognitive and learning disability users, and touch users.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Organizing testing by disability type keeps an audit grounded in user impact rather than abstract checklist items. Each group depends on a distinct cluster of Success Criteria, and walking through the page from each group\'s perspective catches issues that a criterion-by-criterion sweep can miss.'
+      },
+      {
+        type: 'heading',
+        text: 'Screen Reader Users (Blindness)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Text alternatives for images and non-text content (1.1.1)',
+          'Semantic structure: headings, lists, tables, landmarks convey relationships (1.3.1)',
+          'Meaningful sequence: reading order matches visual order (1.3.2)',
+          'Name, role, value exposed for all controls, including custom widgets (4.1.2)',
+          'Live regions and status messages announce dynamic updates (4.1.3)',
+          'Descriptive page titles (2.4.2) and declared page/part language (3.1.1, 3.1.2)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Keyboard and Alternative Input Users'
+      },
+      {
+        type: 'list',
+        items: [
+          'All functionality operable by keyboard (2.1.1) with no keyboard traps (2.1.2)',
+          'Logical focus order (2.4.3) and a visible focus indicator (2.4.7)',
+          'Single-pointer alternatives to path-based or multipoint gestures (2.5.1)',
+          'Alternatives to device-motion actuation like shake or tilt (2.5.4)',
+          'Character-key shortcuts can be turned off or remapped (2.1.4)',
+          'Visible label text is contained in the accessible name for voice-control users (2.5.3 Label in Name)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Deaf and Hard-of-Hearing Users'
+      },
+      {
+        type: 'list',
+        items: [
+          'Captions on prerecorded video with audio (1.2.2) and live captions at AA (1.2.4) — verify accuracy, speaker identification, and meaningful sound effects, not just presence',
+          'Transcripts (media alternatives) for audio-only content (1.2.1)',
+          'No information conveyed by sound alone'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Low Vision Users'
+      },
+      {
+        type: 'list',
+        items: [
+          'Text resizes to 200% without loss of content or functionality (1.4.4)',
+          'Content reflows at 320 CSS pixels width without two-dimensional scrolling (1.4.10)',
+          'No loss of content when users override text spacing (1.4.12)',
+          'Contrast: 4.5:1 for normal text (1.4.3) and 3:1 for UI components and meaningful graphics (1.4.11)',
+          'Content that appears on hover or focus is dismissible, hoverable, and persistent (1.4.13)',
+          'Color is never the only means of conveying information (1.4.1)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Cognitive and Learning Disabilities'
+      },
+      {
+        type: 'list',
+        items: [
+          'Time limits can be turned off, adjusted, or extended (2.2.1); no disruptive auto-playing or moving content (2.2.2, 1.4.2)',
+          'Navigation is consistent across pages (3.2.3) and components are identified consistently (3.2.4)',
+          'Errors are identified in text (3.3.1), with suggestions (3.3.3) and prevention for legal/financial/data transactions (3.3.4)',
+          'Descriptive headings and labels (2.4.6) and clear instructions (3.3.2)',
+          'Multiple ways to find pages — search, site map, navigation (2.4.5)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Touch Users (Mobile and Motor Disabilities)'
+      },
+      {
+        type: 'list',
+        items: [
+          'Touch targets meet minimum size/spacing requirements (2.5.8 Target Size Minimum at AA in WCAG 2.2; 2.5.5 at AAA)',
+          'Content works in both portrait and landscape orientation (1.3.4)',
+          'Complex gestures have single-pointer alternatives (2.5.1)',
+          'Motion-based actuation has UI alternatives and can be disabled (2.5.4)'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'On the exam, expect scenario questions that name a user group and ask which checks belong to it — e.g., reflow and text spacing belong to the low vision checklist, not the screen reader checklist.'
+      }
+    ],
+    relatedTopics: ['disability-user-strategies', 'keyboard-testing', 'screen-reader-testing', 'responsive-accessibility', 'usability-testing-pwd'],
+    examTips: [
+      'Low vision cluster: 200% zoom (1.4.4), reflow at 320px (1.4.10), text spacing (1.4.12), contrast (1.4.3/1.4.11), hover/focus content (1.4.13)',
+      'Cognitive cluster: timing (2.2.1), consistency (3.2.3/3.2.4), errors (3.3.1/3.3.3/3.3.4), descriptive headings/labels (2.4.6)',
+      'Keyboard cluster includes gesture (2.5.1) and motion (2.5.4) alternatives — they help alternative-input users too',
+      'Captions testing means checking accuracy and completeness, not just that a CC button exists',
+      'Label in Name (2.5.3) is primarily for speech-input users who say the visible label aloud'
+    ]
+  },
+  {
+    slug: 'wcag-limitations',
+    title: 'Limitations of WCAG: What the Guidelines Don\'t Cover',
+    category: 'Standards & Guidelines',
+    applicableTo: ['was'],
+    summary: 'WCAG conformance does not guarantee a usable experience — the guidelines have known gaps around cognitive load, certain visual effects, font readability, color-blindness needs beyond contrast, and personalization.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'WCAG is the most important accessibility standard, but it is not a complete description of accessible user experience. Its Success Criteria must be objectively testable, which means genuinely important but hard-to-measure qualities were left out. A skilled evaluator knows what WCAG does NOT cover, so they can report real user barriers that no Success Criterion will ever flag.'
+      },
+      {
+        type: 'heading',
+        text: 'Known Gaps in WCAG Coverage'
+      },
+      {
+        type: 'list',
+        items: [
+          'Pseudomotion and optical-illusion effects: high-contrast patterns and parallax-like illusions can cause discomfort or vestibular symptoms without ever violating the flash or animation criteria',
+          'Color-blindness needs beyond contrast: a chart can pass every contrast ratio yet remain unreadable to color-blind users when categories differ only by hue — patterns, textures, and direct labels are not required',
+          'Font weight: very thin fonts can pass the contrast math while being practically unreadable, because contrast formulas ignore stroke weight',
+          'Ornate and dyslexia-unfriendly typefaces: WCAG does not prohibit decorative or hard-to-read fonts',
+          'Cognitive load and content complexity: AA conformance does not require plain language, short sentences, or simple task flows (3.1.5 Reading Level is only AAA)',
+          'Personalization and customization: WCAG does not require sites to let users adapt the interface to their own needs',
+          'Layout consistency for cognitive users: consistency requirements (3.2.3/3.2.4) are narrow — overall layout predictability is largely uncovered',
+          'Voice interaction: WCAG 2.x was written for visual/keyboard web content and says little about voice-driven interfaces'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Conformance Is Not the Same as Usability'
+      },
+      {
+        type: 'paragraph',
+        text: 'The key principle: a site can minimally conform to WCAG 2.x Level AA and still be exhausting or confusing for real users with disabilities. A page with one hundred tab stops before the main content is keyboard "operable." A page with technically sufficient but vague link text passes. Conformance is the floor, not the ceiling.'
+      },
+      {
+        type: 'paragraph',
+        text: 'This is why mature accessibility programs combine conformance auditing with usability testing involving people with disabilities, and why audit reports often include best-practice recommendations alongside strict failures — clearly labeled as such.'
+      },
+      {
+        type: 'callout',
+        text: 'Exam framing: if a question describes a real barrier (e.g., a hue-only chart with passing contrast, or a punishing cognitive load) and asks whether it fails WCAG, the answer is often "no failure, but a significant usability barrier worth reporting."'
+      }
+    ],
+    relatedTopics: ['wcag-overview', 'usability-concepts', 'cognitive-disabilities', 'wcag-conformance-requirements', 'usability-testing-pwd'],
+    examTips: [
+      'WCAG gaps: pseudomotion, hue-only color coding, font weight/ornate fonts, cognitive load, personalization, layout consistency, voice interaction',
+      'Contrast formulas ignore font weight — thin fonts can pass and still be unreadable',
+      'Plain language is essentially uncovered at A/AA (Reading Level 3.1.5 is AAA)',
+      'Conformance ≠ usability: minimally conforming sites can still be very hard to use',
+      'Report uncovered barriers as best-practice recommendations, distinct from conformance failures'
+    ]
+  },
+  {
+    slug: 'screen-reader-modes',
+    title: 'Screen Reader Modes, Keystrokes & Mobile Gestures',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'Testers must understand browse vs. forms vs. application modes, the quick-navigation keystrokes and element lists of desktop screen readers, and the core touch gestures of VoiceOver and TalkBack.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Desktop screen readers on Windows operate in distinct interaction modes, and a tester who does not understand mode switching will misdiagnose issues. On top of modes, every screen reader offers quick-navigation commands and element lists — testing should exercise them, not just linear reading. Keep in mind that real usage varies widely: these are expert features, and many actual users do not know or use them, sticking to a few keystrokes like the arrow keys and Tab.'
+      },
+      {
+        type: 'heading',
+        text: 'Browse Mode vs. Forms Mode vs. Application Mode'
+      },
+      {
+        type: 'list',
+        items: [
+          'Browse mode (also called virtual or reading mode): the default for web pages. The screen reader intercepts keystrokes — arrow keys read content, single letters jump between element types',
+          'Forms mode (also called focus mode): keystrokes pass through to the page so users can type in fields and operate widgets. JAWS and NVDA switch automatically when focus enters an editable field or interactive widget; users can toggle manually (NVDA: Insert+Space)',
+          'Application mode: triggered by role="application", it disables browse mode entirely — all keys pass to the page and quick-nav stops working',
+          'role="application" is dangerous: it strips users of their reading commands and forces the author to implement ALL keyboard interaction. It is almost never appropriate for ordinary web content'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Quick-Navigation Keystrokes (Browse Mode)'
+      },
+      {
+        type: 'list',
+        items: [
+          'H — next heading (1–6 jump to headings of a specific level)',
+          'L — next list; K — next link in NVDA (JAWS uses U/V for unvisited/visited links); Tab also moves through links and other focusable elements',
+          'F — next form field; E — next edit/text field; B — next button',
+          'T — next table; G — next graphic',
+          'D (NVDA) / R (JAWS) — next landmark/region',
+          'Keystrokes vary between screen readers — verify against each product\'s documentation rather than assuming they are identical'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Element Lists and Rotors'
+      },
+      {
+        type: 'list',
+        items: [
+          'NVDA Elements List: Insert+F7 — dialog listing links, headings, form fields, buttons, and landmarks',
+          'JAWS: Insert+F7 opens the links list; similar lists exist for headings (Insert+F6) and form fields',
+          'VoiceOver rotor: VO+U opens a web rotor for navigating by headings, links, landmarks, form controls, and more',
+          'TalkBack reading controls: choose a granularity — headings, links, controls, words, characters — via the reading controls (swipe up-then-down/down-then-up, or three-finger swipes in newer versions), then swipe up/down to move by it'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Table Navigation'
+      },
+      {
+        type: 'paragraph',
+        text: 'Inside a data table, JAWS and NVDA move cell by cell with Ctrl+Alt+Arrow keys, announcing the associated row and column headers as the user moves. This is the key test for header associations: navigate to an interior data cell and confirm the correct headers are spoken.'
+      },
+      {
+        type: 'heading',
+        text: 'Core Mobile Screen Reader Gestures'
+      },
+      {
+        type: 'list',
+        items: [
+          'Swipe right — move to the next item; swipe left — move to the previous item (VoiceOver and TalkBack)',
+          'Double-tap — activate the currently focused item',
+          'Explore by touch — drag a finger around the screen to hear what is under it',
+          'VoiceOver rotor: rotate two fingers on screen to change what swiping up/down navigates by'
+        ]
+      },
+      {
+        type: 'callout',
+        text: 'A common user strategy is scanning a page by headings or landmarks, then exploring in detail — so verify the page is navigable that way, not just by linear reading. But remember that strategies vary: some users navigate only with the arrow keys and Tab.'
+      }
+    ],
+    relatedTopics: ['screen-readers', 'screen-reader-testing', 'aria-roles', 'browser-at-interoperability', 'accessibility-tree'],
+    examTips: [
+      'Browse/virtual mode intercepts keys for reading; forms/focus mode passes keys to the page; switching is automatic on form fields and widgets',
+      'role="application" kills browse mode and quick-nav — almost never appropriate for web content',
+      'Quick-nav: H headings, L lists, F form fields, T tables, B buttons, D/R landmarks (varies by screen reader)',
+      'NVDA Insert+F7 elements list; VoiceOver rotor VO+U; tables navigate with Ctrl+Alt+Arrows',
+      'Mobile: swipe right/left = next/previous, double-tap = activate, explore by touch'
+    ]
+  },
+  {
+    slug: 'usability-testing-pwd',
+    title: 'Usability Testing with People with Disabilities',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'Usability testing with disabled participants reveals real-world barriers that conformance reviews miss — participants use their own assistive technologies and settings, and findings complement rather than replace standards-based testing.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'A conformance review answers "does this page meet WCAG?" Usability testing with people with disabilities answers a different question: "can real users actually accomplish their goals?" The two methods find different problems, and a mature evaluation practice uses both.'
+      },
+      {
+        type: 'heading',
+        text: 'How It Differs from Conformance Review'
+      },
+      {
+        type: 'list',
+        items: [
+          'Task-based: participants attempt realistic goals (find a product, complete checkout) while observers note where they struggle',
+          'Measures effectiveness, efficiency, and satisfaction — not pass/fail against criteria',
+          'Surfaces issues no Success Criterion covers: cognitive load, confusing flows, exhausting navigation',
+          'Conducted with real users, not expert evaluators simulating users'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Participants Use Their Own Setup'
+      },
+      {
+        type: 'paragraph',
+        text: 'Participants should use their own assistive technologies, devices, and personal settings — their own screen reader with their preferred verbosity and speech rate, their own magnification level, their own switch configuration. A lab-standard setup with unfamiliar AT measures the participant\'s ability to learn new tools, not the product\'s usability. Remote testing often makes own-setup participation easier.'
+      },
+      {
+        type: 'heading',
+        text: 'Diversity Within Disability Groups'
+      },
+      {
+        type: 'paragraph',
+        text: 'Two screen reader users can have completely different experiences of the same page: one is a power user navigating by landmarks at high speech rates, the other recently lost vision and reads linearly with default settings. Skill level, AT choice, browser, age, and co-occurring disabilities all vary. Never treat one participant as representative of an entire disability group.'
+      },
+      {
+        type: 'heading',
+        text: 'Recruiting Considerations'
+      },
+      {
+        type: 'list',
+        items: [
+          'Recruit across disability types AND across experience levels within each type',
+          'Work with disability organizations or specialist recruiting panels; budget extra time and fair compensation',
+          'Ensure the testing logistics are themselves accessible — consent forms, scheduling, venue or remote platform, prototypes',
+          'Pilot the session with the AT in question — a prototype that crashes a screen reader wastes everyone\'s time'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Complement — Never Replace — Standards Testing'
+      },
+      {
+        type: 'paragraph',
+        text: 'Usability testing cannot certify conformance: a handful of participants will not exercise every Success Criterion, and a smooth session does not prove WCAG is met. Equally, conformance testing cannot certify usability. The classic example: a page where every control is keyboard-reachable but the main content sits behind 100 tab stops technically passes SC 2.1.1 — and is exhausting in practice. Accessibility conformance and usability are related but distinct qualities.'
+      },
+      {
+        type: 'callout',
+        text: 'Run usability testing on key user journeys after the major conformance blockers are fixed — otherwise known WCAG failures dominate the sessions and bury new insights.'
+      }
+    ],
+    relatedTopics: ['usability-concepts', 'user-centered-design', 'disability-user-strategies', 'testing-by-disability', 'wcag-limitations'],
+    examTips: [
+      'Participants use their OWN AT and personal settings — never force a lab-standard configuration',
+      'Usability testing complements conformance review; neither replaces the other',
+      'Diversity within groups: two screen reader users can differ as much as two sighted users',
+      'Keyboard-reachable but exhausting (e.g., 100 tab stops) passes WCAG yet fails users — conformance ≠ usability',
+      'Make the test logistics accessible: recruiting, consent, scheduling, and the prototype itself'
+    ]
+  },
+  {
+    slug: 'failures-vs-best-practices',
+    title: 'Failures vs. Best Practices: Mapping Issues to Success Criteria',
+    category: 'Accessibility Testing',
+    applicableTo: ['was'],
+    summary: 'An auditor should report a WCAG failure only when content clearly fails a normative Success Criterion, and report everything else as best-practice advice — keeping the two categories separate preserves the audit\'s credibility.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Not every accessibility problem is a WCAG failure, and not every awkward implementation fails a Success Criterion. One of the hardest evaluator skills is mapping issues to the right criterion — or recognizing that no criterion applies. Over-flagging erodes developer trust as quickly as missing real failures does.'
+      },
+      {
+        type: 'heading',
+        text: 'When to Flag a Failure'
+      },
+      {
+        type: 'list',
+        items: [
+          'The content clearly fails the normative text of a Success Criterion at the claimed level, or',
+          'The content matches a documented WCAG Failure technique (e.g., F65: omitting the alt attribute on img elements)',
+          'Like all techniques, Failures are non-normative — but they document patterns the Working Group considers to fail an SC, so matching one is strong evidence of non-conformance',
+          'Sufficient techniques are NOT required — content can conform without using any documented technique'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Criterion-Boundary Examples'
+      },
+      {
+        type: 'list',
+        items: [
+          'A page with NO headings at all: not a failure of SC 2.4.6 Headings and Labels, because 2.4.6 only requires headings to be descriptive WHERE they exist — it does not require headings to be present. Report missing headings as a strong best-practice recommendation',
+          'Visually styled "fake headings" (bold, enlarged text acting as headings): this IS a failure of SC 1.3.1 Info and Relationships, because a visual structure exists that is not programmatically conveyed',
+          'Placeholder-only labels: placeholder text may technically provide an accessible name in some implementations, but it disappears on input — evaluate against 3.3.2 Labels or Instructions and 1.3.1, and check whether the name persists',
+          'Generic link text ("click here", "read more"): fails SC 2.4.4 only if the purpose cannot be determined from the link together with its programmatically determined context; descriptive text for all links out of context is AAA (2.4.9)'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Deciding Borderline Cases'
+      },
+      {
+        type: 'paragraph',
+        text: 'When a case is ambiguous, consult the non-normative interpretation resources in order of authority: the Understanding documents for the Success Criterion (intent, definitions, examples), the documented Failure techniques, and the ARIA Authoring Practices Guide for expected widget behavior. If after that you still cannot tie the issue to normative SC text, it is not a conformance failure — however much it bothers you.'
+      },
+      {
+        type: 'heading',
+        text: 'Report Failures and Advice Separately'
+      },
+      {
+        type: 'paragraph',
+        text: 'Audit reports should clearly separate conformance failures (with the SC number and level) from best-practice recommendations. Developers and project managers triage by obligation: failures block conformance claims and may carry legal weight; best practices are prioritized on user impact. Mixing the two — or inflating advice into failures — teaches teams to distrust the entire report.'
+      },
+      {
+        type: 'callout',
+        text: 'Litmus test before flagging: "Which Success Criterion\'s normative text does this fail, and would it survive a challenge?" If you cannot answer with an SC number, file it as a best practice.'
+      }
+    ],
+    relatedTopics: ['wcag-overview', 'normative-vs-non-normative', 'testing-fundamentals', 'remediation-prioritization', 'wcag-conformance-requirements'],
+    examTips: [
+      'Only normative SC text determines failures; techniques and Understanding docs are advisory',
+      'Matching a documented Failure technique is strong evidence of non-conformance',
+      'No headings on a page ≠ 2.4.6 failure (it only governs headings that exist); fake visual headings = 1.3.1 failure',
+      'Generic link text fails 2.4.4 only when programmatic context doesn\'t clarify the purpose',
+      'Keep failures and best-practice advice in separate report sections to preserve auditor credibility'
+    ]
+  }
+];

--- a/src/data/knowledgeBase/wasDomain3Topics.js
+++ b/src/data/knowledgeBase/wasDomain3Topics.js
@@ -1,0 +1,172 @@
+/**
+ * WAS BoK Domain Three gap-fill topics — Remediating Accessibility Issues.
+ * Spread into the main `topics` array in index.js.
+ */
+export const wasDomain3Topics = [
+  {
+    slug: 'procurement-expert-role',
+    title: 'The Accessibility Expert\'s Role in Procurement',
+    category: 'Organizational Strategy',
+    applicableTo: ['was'],
+    summary: 'Accessibility experts support both purchasers and vendors during procurement — advising on standards, drafting RFP questions, evaluating ACRs, testing products, shaping contract language, and managing defect mitigation.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Like security and privacy, accessibility is a key consideration during procurement — it is the point where an organization has the best chance to influence how accessible its ICT products and services will be to end users. Accessibility experts play a hands-on role on both sides of the transaction: helping purchasers buy well and helping vendors sell accessible products honestly.'
+      },
+      {
+        type: 'heading',
+        text: 'What Experts Provide to Purchasers'
+      },
+      {
+        type: 'list',
+        items: [
+          'Guidance on good governance practices for accessibility',
+          'Advice on ICT procurement standards, such as EN 301 549 (Europe) and Section 508 (US federal)',
+          'A list of suitable accessibility questions for inclusion in tender documents and Requests for Proposal (RFPs)',
+          'Evaluations of tender responses, Accessibility Conformance Reports (ACRs), and VPATs',
+          'Direct testing of candidate products — never relying on vendor claims alone',
+          'Suggested contract wording regarding accessibility',
+          'Vendor management, including defect remediation and accessibility roadmaps'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'What Experts Provide to Vendors'
+      },
+      {
+        type: 'list',
+        items: [
+          'Auditing existing systems to establish the real state of accessibility',
+          'Remedying identified defects',
+          'Creating Accessibility Conformance Reports (an independently produced ACR carries more credibility than an in-house one)',
+          'Responding to tender questions regarding accessibility'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Reading ACRs Realistically'
+      },
+      {
+        type: 'paragraph',
+        text: 'Ideally every criterion in an ACR\'s reporting table would be "Supports," but in practice very few products fully support every single WCAG or other criterion. "Partially Supports" and "Does Not Support" entries are not automatic disqualifiers — they are helpful signposts telling you which areas to pay attention to during product reviews, so you can judge the real impact on your users. It is preferable that vendors use an independent accessibility professional to create their ACR rather than producing it in-house.'
+      },
+      {
+        type: 'callout',
+        text: 'Exam lens: an ACR claiming "Supports" on every criterion is a reason for more scrutiny, not less. Verify vendor claims by testing the product directly.'
+      },
+      {
+        type: 'heading',
+        text: 'Mitigating Defects in Procured Products'
+      },
+      {
+        type: 'paragraph',
+        text: 'When a product or service you are buying (or already bought) has known accessibility defects, the risk can be mitigated rather than simply accepted:'
+      },
+      {
+        type: 'list',
+        items: [
+          'Obtain a remediation roadmap from the vendor for addressing the known accessibility issues',
+          'Include binding accessibility commitments in contracts for products and services',
+          'Put an alternative access plan in place so affected users can still accomplish their tasks while defects are being fixed',
+          'Monitor vendor performance in relation to defect management',
+          'Consider accessibility performance during contract negotiations and product renewals — renewal time is leverage'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Procurement Maturity Models'
+      },
+      {
+        type: 'paragraph',
+        text: 'Two publicly available, free maturity models specifically address procurement. Policy Driven Adoption for Accessibility (PDAA) is an initiative by the National Association of State Chief Information Officers (NASCIO) that helps procurement organizations choose vendors who can meet accessibility requirements. The W3C Accessibility Maturity Model\'s procurement dimension assesses an organization\'s own sourcing, negotiation, and selection of goods and services — reviewing its use of accessibility processes, criteria, contract language, and decision-making throughout the procurement lifecycle.'
+      },
+    ],
+    relatedTopics: ['procurement-accessibility', 'vpat', 'maturity-models', 'en-301-549', 'section-508', 'stakeholder-communication'],
+    examTips: [
+      'Experts serve purchasers (RFP questions, ACR evaluation, contract wording, testing) AND vendors (audits, fixes, ACR creation, tender responses)',
+      'Very few products fully support every criterion — "Partially Supports" means investigate user impact, not auto-reject',
+      'Prefer independently produced ACRs over in-house vendor self-reports',
+      'Defect mitigation: roadmap + binding contract commitments + alternative access plan + vendor monitoring + renewal leverage',
+      'PDAA (NASCIO) evaluates vendors; the W3C maturity model procurement dimension evaluates your own procurement process'
+    ]
+  },
+  {
+    slug: 'stakeholder-communication',
+    title: 'Communicating Remediation: Stakeholders, Trade-offs, and \'Good Enough\'',
+    category: 'Remediation',
+    applicableTo: ['was'],
+    summary: 'Remediation succeeds when the right stakeholders are aware, educated, and included; when recommendations fit the project\'s real constraints; and when failures and best practices are clearly distinguished and justified.',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'A technically correct remediation plan still fails if nobody acts on it. The WAS Body of Knowledge stresses being able to communicate the purpose, approach, and strategy of remediation — and making the right stakeholders aware, educated, and included in implementation recommendations. Recommending fixes requires knowing how to build accessible content, how to identify issues, and the wisdom to choose a technique appropriate to the circumstances, with all the practical limitations of real-world situations.'
+      },
+      {
+        type: 'heading',
+        text: 'Aware, Educated, and Included'
+      },
+      {
+        type: 'list',
+        items: [
+          'Aware: stakeholders know which issues exist and why they matter to real users',
+          'Educated: each audience understands enough to act on its part of the fix',
+          'Included: stakeholders help shape the recommendations they will implement, instead of receiving a list of orders',
+          'End users with disabilities play an important role in assessing and validating whether a remediation approach actually works'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'Framing for Different Audiences'
+      },
+      {
+        type: 'list',
+        items: [
+          'Developers: be precise about where the problems are, what the problems are, and how to fix them',
+          'Executives and product owners: lead with user impact, legal risk, and cost-benefit; use maturity models and tools to illustrate progress and sustainability',
+          'Affected users: communicate what is being fixed, when, and what alternative access exists in the meantime'
+        ]
+      },
+      {
+        type: 'heading',
+        text: 'The Ideal Solution vs. the "Good Enough" Solution'
+      },
+      {
+        type: 'paragraph',
+        text: 'Part of the expert\'s judgment is characterizing and differentiating the ideal/best solution from the "good enough" solution, respecting the particular project, its environment, the intended target groups, and the available resources. A solution that is feasible in one context (time, money, current state of development, chosen CMS) may be infeasible in another. Recommending strategies that reflect those real conditions helps both users and developers find the most efficient path to accessibility.'
+      },
+      {
+        type: 'callout',
+        text: 'The hybrid approach is the common real-world pattern: immediately remediate critical issues while developing a longer-term plan for a comprehensive rewrite that ensures sustainable accessibility.'
+      },
+      {
+        type: 'heading',
+        text: 'When Minimal Conformance Isn\'t Enough'
+      },
+      {
+        type: 'paragraph',
+        text: 'A website that minimally conforms to a standard can still be difficult to use. A navigation that is fully keyboard-operable but has dozens of tab stops technically meets WCAG, yet keyboard users have a poor experience; verbose alt text is "accessible" but disrupts screen reader use. Beyond normative failures, a good auditor recognizes deficiencies that are not strictly failures and recommends a better practice to achieve a more usable end result — clearly labeled as a recommendation, not a conformance failure.'
+      },
+      {
+        type: 'heading',
+        text: 'Justifying Your Calls with WCAG Supporting Documents'
+      },
+      {
+        type: 'list',
+        items: [
+          'Flag a conformance failure only when the deficiency clearly maps to a documented WCAG Failure or otherwise clearly fails the normative Success Criterion — and describe the underlying deficiency clearly',
+          'The normative text of WCAG defines the requirement but does not prescribe a particular coding solution; Sufficient Techniques are informative, and often multiple techniques can satisfy the same criterion',
+          'For borderline calls, consult the Understanding documents, the Techniques, and the ARIA Authoring Practices Guide (APG) to decide whether an issue is a normative failure or a best-practice recommendation'
+        ]
+      },
+    ],
+    relatedTopics: ['remediation-prioritization', 'remediation-strategies', 'failures-vs-best-practices', 'normative-vs-non-normative', 'usability-testing-pwd', 'procurement-expert-role'],
+    examTips: [
+      'Stakeholders should be aware, educated, AND included — inclusion builds ownership of the fix',
+      'Tailor framing: developers need where/what/how-to-fix; executives need user impact, legal risk, and cost-benefit',
+      '"Good enough" is judged against the project, environment, target groups, and resources — not against perfection',
+      'Hybrid approach = fix critical blockers now, plan the comprehensive rewrite for later',
+      'Use Understanding docs, Techniques, and the APG to justify failure-vs-best-practice calls; only clear SC violations are conformance failures'
+    ]
+  },
+];

--- a/src/data/practiceConfig.js
+++ b/src/data/practiceConfig.js
@@ -1,0 +1,46 @@
+/**
+ * Mock exam configuration mirroring the real IAAP proctored exams.
+ *
+ * CPACC: 100 questions / 120 minutes / 65% to pass, domains weighted 40/40/20.
+ * WAS:    75 questions / 120 minutes / 70% to pass, domains weighted 40/40/20.
+ */
+export const PRACTICE_CONFIG = {
+  cpacc: {
+    courseId: 'cpacc',
+    courseLabel: 'CPACC',
+    courseName: 'Certified Professional in Accessibility Core Competencies',
+    totalQuestions: 100,
+    timeLimitSec: 120 * 60,
+    passPercent: 65,
+    domains: [
+      { domainId: 'domain1', count: 40 },
+      { domainId: 'domain2', count: 40 },
+      { domainId: 'domain3', count: 20 },
+    ],
+  },
+  was: {
+    courseId: 'was',
+    courseLabel: 'WAS',
+    courseName: 'Web Accessibility Specialist',
+    totalQuestions: 75,
+    timeLimitSec: 120 * 60,
+    passPercent: 70,
+    domains: [
+      { domainId: 'was-domain1', count: 30 },
+      { domainId: 'was-domain2', count: 30 },
+      { domainId: 'was-domain3', count: 15 },
+    ],
+  },
+};
+
+/** Timer milestones (in seconds remaining) that trigger announcements. */
+export const TIMER_MILESTONES_SEC = [60 * 60, 30 * 60, 15 * 60, 5 * 60, 60];
+
+/** Milestones announced assertively (urgent). */
+export const ASSERTIVE_MILESTONES_SEC = [5 * 60, 60];
+
+/** Remaining-time threshold for the visual warning state. */
+export const TIMER_WARN_THRESHOLD_SEC = 15 * 60;
+
+/** Maximum stored attempts per course in practice history. */
+export const MAX_HISTORY_PER_COURSE = 20;

--- a/src/data/questions/was-domain1.js
+++ b/src/data/questions/was-domain1.js
@@ -1643,6 +1643,577 @@ export const wasDomain1 = {
       topicLinks: ['disability-user-strategies'],
       difficulty: 'easy',
       tags: ['user-strategies', 'low-vision']
+    },
+    // =============================================
+    // WAS BOK GAP-FILL: WCAG 2.2 & STANDARDS (1301-1328)
+    // =============================================
+    // --- WCAG 2.2 new success criteria (1301-1308) ---
+    {
+      id: 1301,
+      question: "Which success criterion was removed entirely in WCAG 2.2?",
+      options: [
+        "4.1.1 Parsing",
+        "4.1.2 Name, Role, Value",
+        "1.3.1 Info and Relationships",
+        "2.4.7 Focus Visible"
+      ],
+      correct: 0,
+      explanation: "WCAG 2.2 removed SC 4.1.1 Parsing. It was written for an era when assistive technologies parsed markup directly; modern browsers expose a repaired DOM to AT, so the criterion no longer provided unique benefit. Problems it caught, like duplicate IDs breaking label associations, still fail under 1.3.1 or 4.1.2.",
+      wrongExplanations: {
+        1: "4.1.2 Name, Role, Value remains in WCAG 2.2 and is one of the most important criteria for custom widgets.",
+        2: "1.3.1 Info and Relationships remains — it actually absorbs some issues that 4.1.1 used to catch.",
+        3: "2.4.7 Focus Visible remains; WCAG 2.2 added MORE focus-related criteria, it did not remove this one."
+      },
+      topicLinks: ['wcag-22-new-criteria'],
+      difficulty: 'easy',
+      tags: ['wcag-2.2', 'parsing']
+    },
+    {
+      id: 1302,
+      question: "A login form blocks pasting into the password field and offers no other way to sign in. Which WCAG 2.2 success criterion does this most directly fail?",
+      options: [
+        "3.3.8 Accessible Authentication (Minimum) — Level AA",
+        "3.3.7 Redundant Entry — Level A",
+        "2.5.8 Target Size (Minimum) — Level AA",
+        "3.2.6 Consistent Help — Level A"
+      ],
+      correct: 0,
+      explanation: "3.3.8 prohibits requiring a cognitive function test (such as memorizing or transcribing a password) at any authentication step unless an alternative or assistive mechanism exists. Blocking paste defeats password managers, forcing memorization or transcription, which is a classic 3.3.8 failure. (Object recognition and identifying personal content are exceptions at the Minimum level, but they are removed at the AAA Enhanced level, 3.3.9.)",
+      wrongExplanations: {
+        1: "3.3.7 Redundant Entry covers re-entering information within the same process — and it explicitly excepts security-related re-entry like passwords.",
+        2: "2.5.8 is about pointer target dimensions (24 by 24 CSS pixels), not authentication.",
+        3: "3.2.6 requires help mechanisms to appear in a consistent order across a set of pages — unrelated to password entry."
+      },
+      topicLinks: ['wcag-22-new-criteria'],
+      difficulty: 'medium',
+      tags: ['wcag-2.2', 'authentication', 'cognitive']
+    },
+    {
+      id: 1303,
+      question: "A site shows a 'Contact us' link, live chat widget, and FAQ link in its footer — but in a different order on different pages of the site. Which success criterion introduced in WCAG 2.2 is at risk?",
+      options: [
+        "3.2.6 Consistent Help (Level A)",
+        "3.2.3 Consistent Navigation (Level AA)",
+        "3.3.8 Accessible Authentication (Minimum) (Level AA)",
+        "2.4.11 Focus Not Obscured (Minimum) (Level AA)"
+      ],
+      correct: 0,
+      explanation: "3.2.6 Consistent Help (Level A, new in WCAG 2.2) requires that help mechanisms — human contact details, human contact mechanisms, self-help options, and fully automated contact mechanisms — appear in the same relative order on each page in a set of pages where they occur. It primarily benefits people with cognitive disabilities who need to find help in a predictable place.",
+      wrongExplanations: {
+        1: "3.2.3 Consistent Navigation is the near-miss: it covers repeated navigation mechanisms generally and predates 2.2. The new criterion specifically targeting HELP mechanisms is 3.2.6 — and it is Level A.",
+        2: "3.3.8 concerns cognitive function tests during authentication, not the placement of help options.",
+        3: "2.4.11 concerns keyboard focus being hidden by sticky content, not help placement."
+      },
+      topicLinks: ['wcag-22-new-criteria', 'wcag-understandable'],
+      difficulty: 'medium',
+      tags: ['wcag-2.2', 'consistent-help', 'cognitive']
+    },
+    {
+      id: 1304,
+      question: "In a multi-step checkout, the user types their shipping address in step 1, and step 3 demands they retype the same address as the billing address with no way to reuse it. Which WCAG 2.2 success criterion does this fail, and what is a conforming fix?",
+      options: [
+        "3.3.7 Redundant Entry (A) — auto-populate the address or offer a 'same as shipping' option to select",
+        "3.3.7 Redundant Entry (A) — the only fix is to remove the billing address field entirely",
+        "3.3.1 Error Identification (A) — show an error if the addresses do not match",
+        "3.3.8 Accessible Authentication (AA) — addresses count as a cognitive function test"
+      ],
+      correct: 0,
+      explanation: "3.3.7 Redundant Entry (Level A) requires that information previously entered in the same process be auto-populated or available for the user to select. A 'same as shipping address' checkbox or pre-filled fields conforms. Exceptions exist when re-entry is essential, needed for security (passwords), or the previous information is no longer valid.",
+      wrongExplanations: {
+        1: "The SC is correct but the fix is wrong — 3.3.7 does not forbid asking for the information; it requires making the previously entered data available without retyping.",
+        2: "3.3.1 is about identifying input errors, not about forcing re-entry of known information.",
+        3: "3.3.8 applies to cognitive function tests in authentication steps; entering an address during checkout is not authentication."
+      },
+      topicLinks: ['wcag-22-new-criteria', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['wcag-2.2', 'redundant-entry', 'cognitive']
+    },
+    {
+      id: 1305,
+      question: "A kanban board lets users move cards between columns only by dragging with the mouse. The team adds full keyboard support (cut/paste cards with keys) and asks if they now meet WCAG 2.2 SC 2.5.7 Dragging Movements. Do they?",
+      options: [
+        "No — 2.5.7 requires a SINGLE-POINTER alternative to dragging (e.g., click a card, then click a 'move here' target); keyboard support satisfies 2.1.1 but not 2.5.7",
+        "Yes — any non-dragging alternative, including keyboard, satisfies 2.5.7",
+        "No — 2.5.7 bans drag-and-drop interfaces entirely",
+        "Yes — 2.5.7 only applies to native mobile apps, not web content"
+      ],
+      correct: 0,
+      explanation: "2.5.7 (AA) requires that functionality using a dragging movement be achievable by a single pointer WITHOUT dragging, unless dragging is essential or determined by the user agent. It targets pointer users (e.g., tremors, limited dexterity) who can click but cannot sustain press-hold-move-release. Keyboard alternatives are required separately by 2.1.1, but they do not satisfy the single-pointer requirement of 2.5.7.",
+      wrongExplanations: {
+        1: "This is the classic near-miss: keyboard operation is a different requirement (2.1.1). A pointer user who cannot drag may also not use a keyboard efficiently — 2.5.7 specifically demands a pointer-based, non-dragging path.",
+        2: "Drag-and-drop is allowed — there just must also be a single-pointer alternative (or dragging must be essential).",
+        3: "WCAG applies to web content; 2.5.7 absolutely applies to web apps."
+      },
+      topicLinks: ['wcag-22-new-criteria', 'wcag-operable'],
+      difficulty: 'hard',
+      tags: ['wcag-2.2', 'dragging', 'pointer']
+    },
+    {
+      id: 1306,
+      question: "What is the minimum pointer target size required by WCAG 2.2 SC 2.5.8 Target Size (Minimum) at Level AA?",
+      options: [
+        "24 by 24 CSS pixels (with exceptions for spacing, equivalents, inline targets, user-agent controls, and essential presentations)",
+        "44 by 44 CSS pixels",
+        "16 by 16 CSS pixels",
+        "There is no numeric minimum; targets just need visible focus indicators"
+      ],
+      correct: 0,
+      explanation: "2.5.8 Target Size (Minimum), new at Level AA in WCAG 2.2, requires targets to be at least 24 by 24 CSS pixels, with exceptions including sufficient spacing (a 24px circle centered on the target not intersecting other targets), an equivalent control elsewhere, inline text links, user-agent-determined sizing, and essential presentations.",
+      wrongExplanations: {
+        1: "44 by 44 is the stricter AAA requirement from SC 2.5.5 Target Size (Enhanced), introduced in WCAG 2.1 — a frequent exam trap.",
+        2: "16 by 16 is not a WCAG target size threshold.",
+        3: "2.5.8 sets an explicit numeric minimum; focus indicators are covered by different criteria (2.4.7, 2.4.13)."
+      },
+      topicLinks: ['wcag-22-new-criteria'],
+      difficulty: 'easy',
+      tags: ['wcag-2.2', 'target-size', 'pointer']
+    },
+    {
+      id: 1307,
+      question: "A page has a sticky cookie banner across the bottom. When users Tab through the page, focused links behind the banner are partially visible above its edge, but one link is completely covered. How does this fare against WCAG 2.2's Focus Not Obscured criteria?",
+      options: [
+        "The completely covered link fails 2.4.11 (Minimum, AA); the partially covered links pass 2.4.11 but would fail 2.4.12 (Enhanced, AAA)",
+        "All of the covered links fail 2.4.11, because no part of a focused element may ever be hidden at Level AA",
+        "Nothing fails — sticky banners are user interface chrome and exempt from WCAG",
+        "The page fails 2.4.13 Focus Appearance, which is the Level AA criterion about obscured focus"
+      ],
+      correct: 0,
+      explanation: "2.4.11 Focus Not Obscured (Minimum) (AA) requires that a focused component not be ENTIRELY hidden by author-created content — so the fully covered link fails. Partial obscuring passes at AA but violates the AAA version, 2.4.12 Focus Not Obscured (Enhanced), which forbids hiding any part of the focused component.",
+      wrongExplanations: {
+        1: "The 'no part hidden' rule is the AAA Enhanced criterion (2.4.12). At Level AA, only complete obscuring fails.",
+        2: "The cookie banner is author-created content — exactly what these criteria address (sticky headers, footers, banners).",
+        3: "2.4.13 Focus Appearance concerns the size and contrast of the focus indicator, and it is Level AAA, not AA."
+      },
+      topicLinks: ['wcag-22-new-criteria', 'focus-indicators'],
+      difficulty: 'hard',
+      tags: ['wcag-2.2', 'focus', 'low-vision']
+    },
+    {
+      id: 1308,
+      question: "Which two of the nine new WCAG 2.2 success criteria are at Level A?",
+      options: [
+        "3.2.6 Consistent Help and 3.3.7 Redundant Entry",
+        "3.3.8 Accessible Authentication (Minimum) and 2.5.8 Target Size (Minimum)",
+        "2.4.11 Focus Not Obscured (Minimum) and 2.5.7 Dragging Movements",
+        "2.4.13 Focus Appearance and 3.3.9 Accessible Authentication (Enhanced)"
+      ],
+      correct: 0,
+      explanation: "The two Level A additions in WCAG 2.2 are 3.2.6 Consistent Help and 3.3.7 Redundant Entry — both driven by the needs of people with cognitive disabilities. Four new criteria are AA (2.4.11, 2.5.7, 2.5.8, 3.3.8) and three are AAA (2.4.12, 2.4.13, 3.3.9).",
+      wrongExplanations: {
+        1: "Both Accessible Authentication (Minimum) and Target Size (Minimum) are Level AA.",
+        2: "Both Focus Not Obscured (Minimum) and Dragging Movements are Level AA.",
+        3: "Focus Appearance and Accessible Authentication (Enhanced) are both Level AAA."
+      },
+      topicLinks: ['wcag-22-new-criteria'],
+      difficulty: 'medium',
+      tags: ['wcag-2.2', 'conformance-levels']
+    },
+    // --- Normative vs. non-normative & techniques (1309-1312) ---
+    {
+      id: 1309,
+      question: "Which part of the WCAG documentation is normative — that is, required for conformance?",
+      options: [
+        "The success criteria text (with the conformance requirements and glossary)",
+        "The Understanding WCAG documents",
+        "The Techniques for WCAG documents",
+        "The ARIA Authoring Practices Guide"
+      ],
+      correct: 0,
+      explanation: "Only the WCAG standard itself is normative: the success criteria, the conformance requirements, and the glossary definitions they depend on. The Understanding documents and Techniques are informative (non-normative) supporting materials — invaluable for interpretation, but never required.",
+      wrongExplanations: {
+        1: "Understanding documents explain intent, benefits, and examples for each SC — they are explicitly informative.",
+        2: "Techniques describe possible ways to meet criteria; the W3C states they are informative and not required.",
+        3: "The APG is a W3C informative resource about ARIA widget patterns; it is not even part of WCAG."
+      },
+      topicLinks: ['normative-vs-non-normative'],
+      difficulty: 'easy',
+      tags: ['normative', 'wcag-structure']
+    },
+    {
+      id: 1310,
+      question: "An auditor reports a failure of SC 1.1.1 because a team used a custom, undocumented method for providing text alternatives instead of W3C sufficient technique H37 (using alt attributes). The team's method demonstrably exposes correct text alternatives to assistive technology. Who is right?",
+      options: [
+        "The team — techniques are informative and not required; any method that satisfies the normative SC text conforms",
+        "The auditor — sufficient techniques are the only valid ways to meet a success criterion",
+        "The auditor — custom methods require prior W3C approval before they can be used",
+        "Neither — conformance can only be determined by automated testing tools"
+      ],
+      correct: 0,
+      explanation: "Techniques are non-normative. The W3C is explicit that authors may use other methods, including new or custom ones, as long as the success criterion itself is satisfied. Audit findings should cite the normative SC, not the absence of a particular documented technique.",
+      wrongExplanations: {
+        1: "Sufficient techniques are vetted, reliable ways to meet an SC, but the documented list is not exhaustive and is not mandatory.",
+        2: "There is no W3C approval process for individual authors' methods; conformance is judged against the SC text.",
+        3: "Automated tools can only detect a subset of issues; conformance is judged against the success criteria by any reliable means."
+      },
+      topicLinks: ['normative-vs-non-normative'],
+      difficulty: 'medium',
+      tags: ['techniques', 'auditing']
+    },
+    {
+      id: 1311,
+      question: "During an audit you find markup that exactly matches W3C documented failure F65 ('omitting the alt attribute on img elements'). What does matching a documented failure technique mean for conformance?",
+      options: [
+        "The content fails the related success criterion — documented failures are patterns the W3C has determined violate an SC",
+        "Nothing by itself — failure techniques are informative, so matching one has no implications",
+        "The content fails all of WCAG and no conformance claim can be made for the site",
+        "The content is conformant as long as at least one sufficient technique is used elsewhere on the page"
+      ],
+      correct: 0,
+      explanation: "Failure techniques document patterns known to violate specific success criteria. Content that matches a documented failure does not conform to that SC (unless a conforming alternative version is provided). While the failure documents are technically informative, they describe conditions under which the normative SC is not met.",
+      wrongExplanations: {
+        1: "This is the trap: the documents are informative, but what they DESCRIBE is a violation of the normative SC — so the content still fails the criterion.",
+        2: "A failure affects the specific success criterion (and the page's conformance claim at that level), not 'all of WCAG' as a blanket judgment.",
+        3: "Sufficient techniques elsewhere don't neutralize a failure — the failing content itself must be fixed or a conforming alternative provided."
+      },
+      topicLinks: ['normative-vs-non-normative', 'failures-vs-best-practices'],
+      difficulty: 'medium',
+      tags: ['techniques', 'failures', 'auditing']
+    },
+    {
+      id: 1312,
+      question: "A developer insists their tabs widget is 'non-conformant with WAI-ARIA' because it doesn't use the keyboard scheme in the ARIA Authoring Practices Guide (APG). What is the most accurate correction?",
+      options: [
+        "The ARIA specification is normative (e.g., allowed roles and attributes), but the APG is informative guidance — its patterns are recommended, not conformance requirements",
+        "Both the ARIA spec and the APG are normative, so the developer is right",
+        "Neither the ARIA spec nor the APG is normative, so ARIA usage can never be wrong",
+        "The APG is normative but only at WCAG Level AAA"
+      ],
+      correct: 0,
+      explanation: "The WAI-ARIA specification is a normative W3C standard: it defines roles, states, properties, and rules about their use. The APG (and the 'Using ARIA' document) are informative — they describe recommended interaction patterns. Deviating from APG isn't automatically a failure, though the widget must still meet WCAG criteria like 2.1.1 Keyboard and 4.1.2 Name, Role, Value.",
+      wrongExplanations: {
+        1: "The APG is explicitly informative; treating its patterns as a conformance standard is a common misconception.",
+        2: "The ARIA spec itself IS normative — misusing roles or attributes can create real failures (e.g., under 4.1.2).",
+        3: "The APG has no normative status in WCAG at any level — WCAG levels apply to success criteria, not external guides."
+      },
+      topicLinks: ['normative-vs-non-normative', 'aria-overview', 'aria-widget-patterns'],
+      difficulty: 'medium',
+      tags: ['aria', 'normative', 'apg']
+    },
+    // --- Accessibility-supported technologies (1313-1315) ---
+    {
+      id: 1313,
+      question: "What does WCAG conformance requirement 4 ('accessibility supported') require?",
+      options: [
+        "Only ways of using technologies that work with users' assistive technologies and browsers' accessibility features can be relied upon to satisfy success criteria",
+        "All content must be tested with every screen reader on the market before launch",
+        "Only W3C technologies (HTML, CSS, SVG) may be used on a conforming page",
+        "Pages must include a list of supported assistive technologies in the footer"
+      ],
+      correct: 0,
+      explanation: "Conformance requirement 4 says that only accessibility-supported ways of using technologies can be RELIED UPON to satisfy success criteria — meaning the technique must actually work in users' assistive technologies and in the accessibility features of browsers and other user agents, not merely be valid per a specification.",
+      wrongExplanations: {
+        1: "WCAG deliberately does not prescribe how many or which AT/browser combinations must be tested or supported.",
+        2: "Non-W3C technologies may be used, as long as the ways they are used are accessibility supported (and non-interfering).",
+        3: "Documenting tested AT is good audit practice, but it is not what the conformance requirement says."
+      },
+      topicLinks: ['accessibility-supported', 'wcag-conformance-requirements'],
+      difficulty: 'easy',
+      tags: ['accessibility-supported', 'wcag-conformance']
+    },
+    {
+      id: 1314,
+      question: "A team uses a brand-new ARIA attribute that is valid in the latest ARIA specification, but testing shows no major screen reader exposes it yet. Can the team rely on it to satisfy a WCAG success criterion?",
+      options: [
+        "No — per conformance requirement 4, an unsupported usage cannot be relied upon; they need an accessibility-supported method (and may keep the new attribute alongside it)",
+        "Yes — validity against the W3C specification is what WCAG conformance measures",
+        "Yes — screen reader vendors are required to implement W3C specifications within 12 months",
+        "No — and they must also remove the attribute, because unsupported attributes always violate WCAG"
+      ],
+      correct: 0,
+      explanation: "Being in the spec is not the same as being accessibility supported. Since users' AT cannot consume the attribute, it cannot be relied upon for conformance. The team should meet the SC through a supported technique; the newer attribute can remain as progressive enhancement provided it does not interfere (conformance requirement 5).",
+      wrongExplanations: {
+        1: "Spec validity is necessary but insufficient — conformance requirement 4 asks whether the usage actually works with users' AT and browsers.",
+        2: "No such mandate exists; AT support often lags specifications by years, which is exactly why this requirement exists.",
+        3: "Unsupported technologies may still be USED — they just cannot be relied upon, and must not block access to the conforming version."
+      },
+      topicLinks: ['accessibility-supported', 'aria-overview'],
+      difficulty: 'medium',
+      tags: ['accessibility-supported', 'aria', 'at-support']
+    },
+    {
+      id: 1315,
+      question: "How should a developer determine whether a particular HTML/ARIA feature is 'accessibility supported' enough to rely on?",
+      options: [
+        "Test it in the browser + assistive technology combinations their audience uses and consult community support data (e.g., a11ysupport.io) — WCAG itself doesn't define a required set of combinations",
+        "Check that the page passes the W3C HTML validator",
+        "Confirm the feature appears in the WCAG sufficient techniques list, which guarantees universal AT support",
+        "Verify support in one screen reader, since all screen readers expose the accessibility tree identically"
+      ],
+      correct: 0,
+      explanation: "WCAG deliberately leaves 'how much support counts' undefined — it depends on the audience's environments. In practice, developers test real pairings (NVDA + Chrome, JAWS + Edge, VoiceOver + Safari, TalkBack + Chrome) and consult community-maintained databases like a11ysupport.io, re-verifying as browsers and AT update.",
+      wrongExplanations: {
+        1: "Validation checks syntax against the spec; it says nothing about whether assistive technologies actually expose the feature.",
+        2: "Sufficient techniques are vetted ways to meet criteria, but they don't guarantee support in every AT — support still varies and changes over time.",
+        3: "Support differs significantly per screen reader AND per browser pairing — a feature can work in NVDA + Chrome yet fail in VoiceOver + Safari."
+      },
+      topicLinks: ['accessibility-supported', 'browser-at-interoperability', 'screen-reader-testing'],
+      difficulty: 'hard',
+      tags: ['accessibility-supported', 'testing', 'at-support']
+    },
+    // --- Roving tabindex & aria-activedescendant (1316-1319) ---
+    {
+      id: 1316,
+      question: "In a roving tabindex implementation of a toolbar, how are tabindex values managed?",
+      options: [
+        "The active control has tabindex='0' and all others have tabindex='-1'; arrow keys update the values and move real DOM focus to the new active control",
+        "Every control has tabindex='0' so users can Tab to each one",
+        "Controls are numbered tabindex='1', '2', '3'... to enforce the correct order",
+        "The container has tabindex='0' and aria-activedescendant points at the active control"
+      ],
+      correct: 0,
+      explanation: "Roving tabindex keeps the composite widget as a single Tab stop: exactly one item holds tabindex='0' (the roving position), the rest hold tabindex='-1'. On arrow key presses, the script swaps the values and calls .focus() on the new item, so DOM focus genuinely moves and screen readers announce the newly focused control.",
+      wrongExplanations: {
+        1: "Giving every control tabindex='0' makes each one a separate Tab stop, defeating the one-stop composite pattern.",
+        2: "Positive tabindex values hijack the page's global tab order and are a well-known anti-pattern.",
+        3: "That describes the aria-activedescendant pattern — the alternative approach where focus stays on the container instead of roving."
+      },
+      topicLinks: ['focus-management-patterns', 'aria-widget-patterns'],
+      difficulty: 'easy',
+      tags: ['roving-tabindex', 'focus-management', 'keyboard']
+    },
+    {
+      id: 1317,
+      question: "In a listbox using aria-activedescendant, what happens to DOM focus as the user presses arrow keys through the options?",
+      options: [
+        "DOM focus stays on the listbox container; the aria-activedescendant attribute is updated to the id of the active option, which screen readers announce as if focused",
+        "DOM focus moves to each option element in turn",
+        "DOM focus moves to the document body between key presses",
+        "Focus alternates between the container and the active option on every key press"
+      ],
+      correct: 0,
+      explanation: "With aria-activedescendant, document.activeElement never leaves the focusable container. Arrow key handlers update the container's aria-activedescendant value to reference the active option's unique id; assistive technologies then treat that referenced element as the point of interest and announce it.",
+      wrongExplanations: {
+        1: "Moving real focus to each option describes the roving tabindex pattern, not aria-activedescendant.",
+        2: "Focus never drops to the body — that would eject the user from the widget entirely.",
+        3: "There is no alternation; the whole point of the pattern is that focus remains stationary on the container."
+      },
+      topicLinks: ['focus-management-patterns', 'aria-states-properties'],
+      difficulty: 'medium',
+      tags: ['aria-activedescendant', 'focus-management', 'listbox']
+    },
+    {
+      id: 1318,
+      question: "Why must an editable combobox (a text input that filters a popup list of options) use aria-activedescendant rather than roving tabindex for its list options?",
+      options: [
+        "DOM focus must stay in the text input so the user can keep typing while arrow keys highlight options; moving real focus into the list would break text entry",
+        "Roving tabindex is deprecated in the ARIA specification",
+        "aria-activedescendant performs better because it avoids JavaScript event handlers",
+        "Screen readers cannot announce elements that receive real DOM focus inside a popup"
+      ],
+      correct: 0,
+      explanation: "In an editable combobox, typing and option navigation are interleaved — the user types to filter, arrows to a suggestion, types more to refine. That only works if DOM focus remains in the input. aria-activedescendant lets the input keep focus while telling AT which option in the popup is active.",
+      wrongExplanations: {
+        1: "Roving tabindex is not deprecated — it remains the recommended default for most composite widgets like toolbars and tab lists.",
+        2: "Both patterns require JavaScript key handling; performance is not the deciding factor.",
+        3: "Screen readers announce focused elements in popups fine — the issue is that the user could no longer type in the input."
+      },
+      topicLinks: ['focus-management-patterns', 'aria-widget-patterns'],
+      difficulty: 'hard',
+      tags: ['aria-activedescendant', 'combobox', 'focus-management']
+    },
+    {
+      id: 1319,
+      question: "A custom listbox uses aria-activedescendant correctly for announcements, but sighted keyboard users report two problems: they can't see which option is active, and arrowing past the visible area 'loses' the highlight. What is the likely cause?",
+      options: [
+        "Since real focus never moves, :focus styles never apply to options and the browser never auto-scrolls — the script must style the active option explicitly and call scrollIntoView()",
+        "aria-activedescendant is unsupported in all browsers, so the widget must be rebuilt with roving tabindex",
+        "The options are missing aria-live attributes, which control visual highlighting",
+        "The container needs tabindex='1' to enable scrolling behavior"
+      ],
+      correct: 0,
+      explanation: "These are the two classic aria-activedescendant pitfalls. DOM focus stays on the container, so the option never matches :focus and gets no native focus ring (risking SC 2.4.7 Focus Visible), and the browser has no reason to scroll an unfocused element into view. Authors must add explicit active styling (e.g., on [aria-selected='true']) and programmatically scroll the active option into view.",
+      wrongExplanations: {
+        1: "aria-activedescendant is broadly supported; the bug is missing visual styling and scrolling logic, not the pattern itself.",
+        2: "aria-live governs announcements of dynamic content changes — it has nothing to do with visual highlighting.",
+        3: "Positive tabindex values are an anti-pattern and have no effect on scrolling."
+      },
+      topicLinks: ['focus-management-patterns', 'focus-indicators'],
+      difficulty: 'hard',
+      tags: ['aria-activedescendant', 'focus-visible', 'pitfalls']
+    },
+    // --- EN 301 549 & EU Web Accessibility Directive (1320-1322) ---
+    {
+      id: 1320,
+      question: "How does EN 301 549 go beyond WCAG for a public-sector web team in the EU?",
+      options: [
+        "Besides clause 9 (which incorporates WCAG 2.1 AA for web content), other clauses add requirements — e.g., for non-web documents (clause 10), software (clause 11), and media player capabilities like caption playback (clause 7)",
+        "It upgrades all WCAG AAA criteria to mandatory for web pages",
+        "It only restates WCAG 2.1 AA with no additional requirements of any kind",
+        "It replaces WCAG entirely with an unrelated European test methodology"
+      ],
+      correct: 0,
+      explanation: "EN 301 549 is an ICT-wide standard. Clause 9 incorporates WCAG 2.1 Level AA for web content, but the standard also covers non-web documents (clause 10), software and mobile apps (clause 11), documentation and support services (clause 12), and functional requirements such as captioning playback and audio description capabilities for media players (clause 7) — obligations WCAG alone does not impose.",
+      wrongExplanations: {
+        1: "EN 301 549 does not raise the web requirement to AAA; the web baseline is WCAG 2.1 AA.",
+        2: "It is much broader than a restatement — its coverage of documents, software, hardware, and support services is precisely how it extends beyond WCAG.",
+        3: "It builds directly on WCAG rather than replacing it; clause 9 mirrors WCAG 2.1 AA."
+      },
+      topicLinks: ['en-301-549', 'wcag-overview'],
+      difficulty: 'medium',
+      tags: ['en-301-549', 'european-standards']
+    },
+    {
+      id: 1321,
+      question: "Beyond making content conform to the standard, what does the EU Web Accessibility Directive (2016/2102) require of public sector websites and mobile apps?",
+      options: [
+        "Publishing an accessibility statement (including known non-accessible content) and providing a feedback mechanism, with member states monitoring and reporting on compliance",
+        "Annual third-party certification of every page by a private auditor",
+        "Hosting all content on EU-based servers",
+        "Translating all content into every official EU language"
+      ],
+      correct: 0,
+      explanation: "The Web Accessibility Directive requires public sector bodies to publish and maintain an accessibility statement describing conformance status and known exceptions, to provide a feedback mechanism so users can report barriers and request inaccessible content, and it obligates member states to monitor compliance periodically and report to the European Commission. EN 301 549 is the harmonized standard giving presumption of conformity.",
+      wrongExplanations: {
+        1: "The directive establishes member-state monitoring, not mandatory private third-party certification of every page.",
+        2: "Server location is a data/sovereignty matter, not part of the accessibility directive.",
+        3: "Language translation requirements are unrelated to the directive's accessibility obligations."
+      },
+      topicLinks: ['en-301-549'],
+      difficulty: 'medium',
+      tags: ['web-accessibility-directive', 'european-standards', 'legal']
+    },
+    {
+      id: 1322,
+      question: "What is the purpose of Annex A of EN 301 549?",
+      options: [
+        "It contains tables mapping which of the standard's requirements apply for presumed conformity with the Web Accessibility Directive for websites and mobile apps",
+        "It is the full text of WCAG 2.1 reproduced verbatim",
+        "It lists the assistive technology products officially approved in the EU",
+        "It defines the financial penalties for non-compliance in each member state"
+      ],
+      correct: 0,
+      explanation: "Annex A of EN 301 549 contains the tables (e.g., Table A.1) that identify exactly which clauses and requirements of the standard are relevant to the essential requirements of the Web Accessibility Directive — i.e., what a public sector website or mobile app must satisfy to enjoy presumption of conformity with the directive.",
+      wrongExplanations: {
+        1: "WCAG criteria are incorporated by reference and restated within clause 9, not reproduced as Annex A.",
+        2: "Neither the EU nor the standard maintains an 'approved AT' product list.",
+        3: "Penalties are determined by individual member states' implementing legislation, not by the technical standard."
+      },
+      topicLinks: ['en-301-549'],
+      difficulty: 'hard',
+      tags: ['en-301-549', 'web-accessibility-directive', 'annex-a']
+    },
+    // --- SPA depth: history, announcements, AJAX updates (1323-1325) ---
+    {
+      id: 1323,
+      question: "A SPA swaps views without using the History API (no pushState or popstate handling). What accessibility and usability problem results?",
+      options: [
+        "The browser back button no longer maps to the user's navigation — pressing Back can exit the app entirely or land on stale state, breaking a deeply ingrained recovery mechanism",
+        "The page's CSS custom properties stop cascading",
+        "All ARIA attributes are removed from the DOM on each view swap",
+        "Screen readers refuse to render content that wasn't loaded with a full page request"
+      ],
+      correct: 0,
+      explanation: "Users — especially those with cognitive disabilities, and screen reader users who rely on predictable mental models — expect Back to undo their last navigation. If a SPA changes views without pushing history entries, Back leaves the site or restores a mismatched state. Integrating with the History API (as client-side routers do) preserves Back/Forward, bookmarks, and shareable URLs.",
+      wrongExplanations: {
+        1: "CSS behavior is unaffected by how navigation state is managed.",
+        2: "View swapping doesn't strip ARIA attributes; the markup is whatever the app renders.",
+        3: "Screen readers read whatever is in the DOM regardless of how it was loaded — the problem is navigation state, not rendering."
+      },
+      topicLinks: ['spa-accessibility', 'javascript-accessibility'],
+      difficulty: 'medium',
+      tags: ['spa', 'history-api', 'routing']
+    },
+    {
+      id: 1324,
+      question: "Compare two route-change strategies in a SPA: (A) move focus to the new view's h1 (tabindex='-1'); (B) announce the new view via an aria-live region while leaving focus untouched. What is the key trade-off?",
+      options: [
+        "A repositions keyboard and screen reader users in the new content but interrupts; B informs without repositioning, leaving keyboard users stranded in stale content — so robust implementations often combine announcement with focus management",
+        "A and B are functionally identical because focusing an element always triggers a live region announcement",
+        "B is strictly better because moving focus programmatically violates WCAG 3.2.1 On Focus",
+        "A is invalid because headings can never legally receive focus in HTML"
+      ],
+      correct: 0,
+      explanation: "Moving focus to the new h1 gives screen reader AND keyboard users a real foothold in the new view (announced via the focus event), at the cost of an abrupt context move. A live region only answers 'what changed?' — focus remains in the removed/old view, so the next Tab press goes somewhere unpredictable. Mature SPAs typically move focus and may supplement with an announcement.",
+      wrongExplanations: {
+        1: "They are not identical — live regions don't move focus, and focusing an element is announced through focus semantics, not through live region machinery.",
+        2: "3.2.1 On Focus prohibits unexpected context changes when a component RECEIVES focus; deliberately moving focus after a user-initiated navigation is accepted practice.",
+        3: "Any element can receive programmatic focus with tabindex='-1' — focusing the h1 is a widely recommended technique."
+      },
+      topicLinks: ['spa-accessibility', 'aria-live-regions'],
+      difficulty: 'hard',
+      tags: ['spa', 'focus-management', 'aria-live']
+    },
+    {
+      id: 1325,
+      question: "As a user types into a search field, results filter live in a region below. What is the most appropriate way to notify screen reader users of the updates?",
+      options: [
+        "A polite live region announcing a summary like '12 results shown' — without moving focus, which would disrupt typing",
+        "Move focus to the results list after every keystroke",
+        "Use role='alert' on the results container so every change interrupts immediately",
+        "Reload the entire page after each keystroke so screen readers start fresh"
+      ],
+      correct: 0,
+      explanation: "For frequent, non-critical AJAX updates, a polite live region with a concise summary (result count) informs users when they pause typing, without yanking focus from the input. Announcing the full result list or interrupting assertively would be overwhelming; moving focus would make typing impossible.",
+      wrongExplanations: {
+        1: "Stealing focus on every keystroke makes the search box unusable — users could never type more than one character.",
+        2: "role='alert' is assertive — it interrupts speech on every update, which is hostile for something that changes on each keystroke.",
+        3: "Full page reloads destroy the interaction model and are exactly what AJAX patterns exist to avoid; the task is to communicate updates accessibly, not eliminate them."
+      },
+      topicLinks: ['aria-live-regions', 'spa-accessibility', 'javascript-accessibility'],
+      difficulty: 'medium',
+      tags: ['aria-live', 'ajax', 'search']
+    },
+    // --- Screen reader modes & touch gestures (1326-1327) ---
+    {
+      id: 1326,
+      question: "A custom date picker works perfectly with a mouse, but NVDA users report that pressing arrow keys reads the page text instead of changing the date. What is the most likely explanation?",
+      options: [
+        "NVDA is in browse mode, where arrow keys are intercepted by the virtual buffer for reading; the widget needs proper interactive roles/focus so the screen reader switches to focus (forms) mode and passes keys through",
+        "Arrow keys can never be used by web applications while any screen reader is running",
+        "NVDA does not support JavaScript event handlers",
+        "The date picker needs aria-live='assertive' to receive keyboard events"
+      ],
+      correct: 0,
+      explanation: "Windows screen readers like NVDA and JAWS have two modes: browse/virtual mode, where keystrokes (arrows, H for headings, etc.) navigate a virtual copy of the page, and focus/forms mode, where keys pass through to the web app. Screen readers switch to focus mode automatically when the user moves into a recognized interactive widget — which requires correct roles (e.g., grid, spinbutton), focus management, and states. Without them, arrow presses never reach the widget's handlers.",
+      wrongExplanations: {
+        1: "Web apps receive arrow keys fine once the screen reader is in focus mode — composite widgets depend on exactly this.",
+        2: "NVDA runs against the browser's accessibility tree and DOM; JavaScript handlers work normally when keys pass through.",
+        3: "aria-live controls announcements of content changes; it has no effect on keyboard event routing or modes."
+      },
+      topicLinks: ['screen-reader-modes', 'focus-management-patterns', 'screen-readers'],
+      difficulty: 'hard',
+      tags: ['screen-reader-modes', 'nvda', 'keyboard']
+    },
+    {
+      id: 1327,
+      question: "How does a VoiceOver or TalkBack user typically move to the next element and activate a control on a touch screen?",
+      options: [
+        "Swipe right to move to the next element, then double-tap anywhere to activate the current item",
+        "Single-tap the control directly, exactly as without a screen reader",
+        "Triple-tap with two fingers to move, pinch to activate",
+        "Shake the device to advance and long-press to activate"
+      ],
+      correct: 0,
+      explanation: "Mobile screen readers intercept touch input: a right swipe moves the reading cursor to the next element (left swipe goes back), and a double-tap activates whatever currently has the screen reader cursor. Users can also explore by touch — dragging a finger to hear items under it. Standard single taps no longer activate controls directly.",
+      wrongExplanations: {
+        1: "With the screen reader running, a single tap moves the cursor/announces the item rather than activating it — activation requires double-tap.",
+        2: "These are not the standard navigation/activation gestures; multi-finger gestures perform other functions (e.g., scrolling, reading from top).",
+        3: "Shake and long-press are not the navigation model of VoiceOver or TalkBack."
+      },
+      topicLinks: ['screen-readers', 'disability-user-strategies'],
+      difficulty: 'easy',
+      tags: ['mobile', 'voiceover', 'talkback', 'touch']
+    },
+    // --- Deaf and deaf-blind user strategies (1328) ---
+    {
+      id: 1328,
+      question: "Your video content has accurate captions. A deaf-blind user reports they still cannot access it. Which addition serves them, and what serves Deaf users whose first language is sign language?",
+      options: [
+        "A text transcript, readable on a refreshable braille display, serves deaf-blind users; sign language interpretation (SC 1.2.6, Level AAA) serves Deaf signers",
+        "Higher-contrast captions serve deaf-blind users; transcripts serve sign language users",
+        "Audio description serves both groups",
+        "Nothing further is needed — captions satisfy every auditory-disability use case"
+      ],
+      correct: 0,
+      explanation: "Captions are visual, so a deaf-blind user cannot perceive them; a complete text transcript can be read line-by-line on a refreshable braille display. For many Deaf people, a national sign language is their first language and written text a second one — SC 1.2.6 Sign Language (Prerecorded), Level AAA, addresses providing sign language interpretation for prerecorded audio content.",
+      wrongExplanations: {
+        1: "Contrast doesn't help a user who cannot see the screen at all, and transcripts are not a sign-language substitute — this reverses the appropriate accommodations.",
+        2: "Audio description narrates visual information for blind users who can hear — it is inaccessible to both deaf-blind users and unnecessary for Deaf users.",
+        3: "Captions don't reach deaf-blind users (visual) and may be harder than signing for Deaf first-language signers — that's why transcripts and SC 1.2.6 exist."
+      },
+      topicLinks: ['disability-user-strategies', 'wcag-perceivable'],
+      difficulty: 'medium',
+      tags: ['deaf-blind', 'captions', 'transcripts', 'braille']
     }
   ]
 };

--- a/src/data/questions/was-domain2.js
+++ b/src/data/questions/was-domain2.js
@@ -1634,6 +1634,670 @@ export const wasDomain2 = {
       topicLinks: ['disability-user-strategies'],
       difficulty: 'hard',
       tags: ['user-testing']
+    },
+    // =============================================
+    // WCAG CONFORMANCE REQUIREMENTS (1401-1407)
+    // =============================================
+    {
+      id: 1401,
+      question: "According to WCAG's normative conformance requirements, what is the smallest unit to which a conformance claim can apply?",
+      options: [
+        "An individual component or widget",
+        "A full web page",
+        "An entire website",
+        "A DOM subtree identified by a CSS selector"
+      ],
+      correct: 1,
+      explanation: "The 'Full Pages' conformance requirement states that conformance (and conformance level) is for full web pages only. Conformance cannot be achieved if part of a page is excluded — there is no partial-page conformance.",
+      wrongExplanations: {
+        0: "A single component cannot conform on its own — the Full Pages requirement explicitly rules out claiming conformance for only part of a page.",
+        2: "Conformance is evaluated and claimed per page, not per website. A site-wide claim is really a set of per-page claims (and WCAG-EM sampling only estimates site-wide status).",
+        3: "WCAG has no mechanism for scoping conformance to a DOM subtree — the whole page, including embedded and third-party content, is evaluated."
+      },
+      topicLinks: ['wcag-conformance-requirements', 'wcag-em'],
+      difficulty: 'easy',
+      tags: ['conformance', 'wcag']
+    },
+    {
+      id: 1402,
+      question: "A legacy data-visualization page cannot be made accessible this quarter, so the team publishes an accessible HTML version of the same content. For the original page to claim conformance via this conforming alternate version, which condition must be met?",
+      options: [
+        "The alternate version provides the same information and functionality, is as up to date, itself conforms, and is reachable from the non-conforming page via an accessibility-supported mechanism",
+        "The alternate version contains at least the essential content, with a note describing what was omitted",
+        "The alternate version is plain text with no images or interactivity",
+        "The alternate version is linked from the website's homepage footer"
+      ],
+      correct: 0,
+      explanation: "A conforming alternate version must be equivalent (same information and functionality in the same language), as up to date as the non-conforming content, conform at the claimed level, and be reachable from the non-conforming page through an accessibility-supported mechanism (or the non-conforming page must only be reachable from the conforming one).",
+      wrongExplanations: {
+        1: "Equivalence is mandatory — the alternate must provide ALL of the same information and functionality, not just the essentials with omissions noted.",
+        2: "There is no plain-text requirement. The alternate version can use any technologies as long as it conforms; it must match the original's functionality, which plain text often cannot.",
+        3: "A general site-wide footer link is not sufficient — users on the non-conforming page must be able to reach the alternate from that page via a mechanism they can actually perceive and operate."
+      },
+      topicLinks: ['wcag-conformance-requirements'],
+      difficulty: 'medium',
+      tags: ['conformance', 'alternate-version']
+    },
+    {
+      id: 1403,
+      question: "An e-commerce checkout consists of cart, shipping, payment, and confirmation pages. The payment page fails SC 3.3.1 Error Identification; the other three pages pass everything at Level AA. Which pages can claim Level AA conformance?",
+      options: [
+        "The cart, shipping, and confirmation pages, since they individually pass",
+        "All four pages, because only one Success Criterion failed",
+        "None of the pages in the checkout process",
+        "Only the confirmation page, because it comes after the failing step"
+      ],
+      correct: 2,
+      explanation: "The 'Complete Processes' conformance requirement states that when a page is part of a process — a series of steps needed to complete an activity — all pages in the process must conform at the claimed level or better. One failing step disqualifies every page in the process.",
+      wrongExplanations: {
+        0: "Individually passing is not enough for pages in a process. The Complete Processes requirement makes conformance collective across all steps of the workflow.",
+        1: "A single failing Success Criterion is enough to fail a page, and a failing page in a process disqualifies the whole process.",
+        3: "Position in the sequence is irrelevant — the requirement applies to every page in the process, before and after the failing step."
+      },
+      topicLinks: ['wcag-conformance-requirements'],
+      difficulty: 'medium',
+      tags: ['conformance', 'complete-processes']
+    },
+    {
+      id: 1404,
+      question: "Which set of Success Criteria applies to ALL content on a page — including technologies that are NOT relied upon for conformance — under WCAG's non-interference requirement?",
+      options: [
+        "1.1.1 Non-text Content, 1.4.3 Contrast (Minimum), 2.4.7 Focus Visible, 4.1.2 Name, Role, Value",
+        "1.4.2 Audio Control, 2.1.2 No Keyboard Trap, 2.3.1 Three Flashes or Below Threshold, 2.2.2 Pause, Stop, Hide",
+        "2.1.1 Keyboard, 2.4.1 Bypass Blocks, 3.1.1 Language of Page, 1.3.1 Info and Relationships",
+        "1.4.1 Use of Color, 2.4.3 Focus Order, 2.5.1 Pointer Gestures, 3.2.1 On Focus"
+      ],
+      correct: 1,
+      explanation: "The non-interference requirement names exactly four Success Criteria that apply to all page content, even content not relied upon for conformance: 1.4.2 Audio Control, 2.1.2 No Keyboard Trap, 2.3.1 Three Flashes or Below Threshold, and 2.2.2 Pause, Stop, Hide. Failing any of these blocks users from using the rest of the page.",
+      wrongExplanations: {
+        0: "These are important Level A/AA criteria, but they apply only to content relied upon for conformance — they are not part of the non-interference set.",
+        2: "Keyboard operability, bypass blocks, language, and info/relationships apply to relied-upon content; they are not the four non-interference criteria.",
+        3: "None of these is in the non-interference set. The four non-interference criteria all involve content that can actively block or harm any user of the page (audio drowning out a screen reader, focus traps, seizure-inducing flashes, uncontrollable motion)."
+      },
+      topicLinks: ['wcag-conformance-requirements'],
+      difficulty: 'hard',
+      tags: ['conformance', 'non-interference']
+    },
+    {
+      id: 1405,
+      question: "A page embeds a third-party promotional widget that traps keyboard focus. The team documents that the widget is 'not relied upon' and excludes it from their conformance claim. Why does the page still fail to conform?",
+      options: [
+        "Third-party content is always exempt, so the page actually does conform",
+        "Excluding content requires written permission from the W3C",
+        "SC 2.1.2 No Keyboard Trap is a non-interference criterion that applies to all content on the page, even content not relied upon",
+        "Keyboard traps are only a problem at Level AAA"
+      ],
+      correct: 2,
+      explanation: "Declaring content 'not relied upon' does not exempt it from the four non-interference criteria. A keyboard trap (SC 2.1.2) anywhere on the page blocks keyboard and screen reader users from the entire page, so the page cannot conform regardless of how the claim is scoped.",
+      wrongExplanations: {
+        0: "There is no blanket third-party exemption in WCAG. Third-party content is part of the full page, and at minimum the non-interference criteria always apply to it.",
+        1: "The W3C plays no role in individual conformance claims — and no permission process can exempt content from the non-interference requirements.",
+        3: "SC 2.1.2 No Keyboard Trap is Level A — the lowest, most fundamental level — and it is one of the four criteria that apply to all page content."
+      },
+      topicLinks: ['wcag-conformance-requirements', 'keyboard-testing'],
+      difficulty: 'medium',
+      tags: ['conformance', 'non-interference', 'third-party']
+    },
+    {
+      id: 1406,
+      question: "A product page meets every Success Criterion except within an embedded third-party video player, which fails several Level A criteria. Can the page claim Level A conformance 'with the exception of the video player'?",
+      options: [
+        "Yes, as long as the exception is documented in the accessibility statement",
+        "Yes, because third-party content does not count toward conformance",
+        "Yes, if the player is wrapped in an iframe",
+        "No — conformance applies to full pages only, and part of a page cannot be excluded"
+      ],
+      correct: 3,
+      explanation: "The Full Pages conformance requirement prohibits partial-page conformance: 'Conformance (and conformance level) is for full web page(s) only, and cannot be achieved if part of a web page is excluded.' The embedded player is part of the page, so the page does not conform.",
+      wrongExplanations: {
+        0: "Documenting an exception does not create one — WCAG has a 'statement of partial conformance' concept for uncontrolled third-party content, but that is explicitly NOT a conformance claim.",
+        1: "Third-party content rendered on the page is part of the full page and counts toward (or against) conformance.",
+        2: "Using an iframe changes nothing — embedded content, iframe or not, is evaluated as part of the page it appears on."
+      },
+      topicLinks: ['wcag-conformance-requirements'],
+      difficulty: 'easy',
+      tags: ['conformance', 'full-pages']
+    },
+    {
+      id: 1407,
+      question: "A team builds a key feature with a cutting-edge web technology that does not yet work with screen readers or browser accessibility features. Under conformance requirement 4 ('Only Accessibility-Supported Ways of Using Technologies'), what is true?",
+      options: [
+        "The technology may still be used, but it cannot be relied upon to satisfy any Success Criterion — the information and functionality must also be available in an accessibility-supported way",
+        "The technology is prohibited from appearing anywhere on a conforming page",
+        "The technology is acceptable as long as a JavaScript polyfill exists",
+        "This requirement only applies to pages claiming Level AAA"
+      ],
+      correct: 0,
+      explanation: "Non-accessibility-supported technologies can be used — WCAG does not ban them — but they cannot be relied upon for conformance. Everything needed to meet the Success Criteria must also work in accessibility-supported ways, and the non-supported content must still satisfy the non-interference criteria.",
+      wrongExplanations: {
+        1: "WCAG explicitly allows non-accessibility-supported technologies to be used, provided they are not relied upon and do not interfere with the rest of the page.",
+        2: "A polyfill is irrelevant unless it actually makes the way the technology is used work with assistive technologies — accessibility support is about real interoperability with users' AT and browsers.",
+        3: "All five conformance requirements, including accessibility support, apply at every conformance level: A, AA, and AAA."
+      },
+      topicLinks: ['wcag-conformance-requirements', 'accessibility-supported'],
+      difficulty: 'hard',
+      tags: ['conformance', 'accessibility-supported']
+    },
+    // =============================================
+    // BROWSER + AT INTEROPERABILITY (1408-1411)
+    // =============================================
+    {
+      id: 1408,
+      question: "Which browser and screen reader combination is recommended for testing because the vendor develops and tests them together?",
+      options: [
+        "VoiceOver + Chrome on macOS",
+        "JAWS + Safari on macOS",
+        "VoiceOver + Safari on macOS and iOS",
+        "TalkBack + Firefox on Android"
+      ],
+      correct: 2,
+      explanation: "Apple builds VoiceOver and Safari as a pair and tests them together, making VoiceOver + Safari the recommended combination on macOS and iOS. Other standard pairings include JAWS + Chrome, NVDA + Firefox/Chrome, Narrator + Edge, and TalkBack + Chrome.",
+      wrongExplanations: {
+        0: "VoiceOver works far better with Safari than with Chrome on Apple platforms — VoiceOver + Chrome is a mismatched pairing that can produce misleading test results.",
+        1: "JAWS is a Windows-only screen reader; it does not run on macOS at all.",
+        3: "TalkBack is primarily developed and tested with Chrome (both Google products) — Chrome, not Firefox, is the recommended Android pairing."
+      },
+      topicLinks: ['browser-at-interoperability', 'screen-reader-testing'],
+      difficulty: 'easy',
+      tags: ['screen-readers', 'browser-pairing', 'interoperability']
+    },
+    {
+      id: 1409,
+      question: "A custom disclosure widget announces its expanded/collapsed state correctly in NVDA + Firefox but not in JAWS + Chrome. What is the most likely underlying reason such differences exist at all?",
+      options: [
+        "JAWS does not support ARIA attributes",
+        "Browsers map markup to platform accessibility APIs differently, and each screen reader applies its own heuristics to what the API exposes",
+        "Chrome does not build an accessibility tree",
+        "NVDA reads the raw HTML source instead of the accessibility tree"
+      ],
+      correct: 1,
+      explanation: "Assistive technologies consume what the browser exposes through platform accessibility APIs. Each browser builds and maps its accessibility tree slightly differently, and each screen reader layers its own interpretation and repair heuristics on top — so the same markup can behave differently in different pairings.",
+      wrongExplanations: {
+        0: "JAWS has extensive ARIA support — historically among the best. Individual mapping differences, not wholesale lack of support, cause pairing-specific behavior.",
+        2: "Chrome absolutely builds an accessibility tree and exposes it through platform APIs (and DevTools can display it). The differences lie in how trees are built and interpreted, not whether they exist.",
+        3: "NVDA, like all modern screen readers, works from the browser's accessibility API output, not by parsing raw HTML."
+      },
+      topicLinks: ['browser-at-interoperability', 'accessibility-tree'],
+      difficulty: 'medium',
+      tags: ['interoperability', 'accessibility-apis']
+    },
+    {
+      id: 1410,
+      question: "A tester verifies that a combobox is coded exactly per the ARIA specification. It announces correctly in NVDA and VoiceOver across browsers, but one screen reader mis-announces it in every browser tested. What is the most reasonable conclusion?",
+      options: [
+        "The markup is wrong and must be rewritten until that screen reader announces it correctly",
+        "The browsers all share the same accessibility API bug",
+        "The component fails SC 4.1.2 Name, Role, Value",
+        "The defect is likely a bug in that screen reader and should be reported to the AT vendor"
+      ],
+      correct: 3,
+      explanation: "When spec-correct markup fails with one AT across multiple browsers while working everywhere else, the pattern points to an AT bug. The right move is to report it upstream to the vendor (and possibly document a workaround), not to distort correct code.",
+      wrongExplanations: {
+        0: "Hacking spec-correct markup until one screen reader sounds right — 'coding to the screen reader' — frequently breaks the other pairings and creates unmaintainable code.",
+        1: "If the issue followed the screen reader across different browsers, the browsers' independent API mappings are unlikely to share the same bug — the common factor is the AT.",
+        2: "SC 4.1.2 is about the author programmatically exposing name, role, and value. If the markup correctly exposes them per spec, an AT's failure to voice them properly is not an authoring failure."
+      },
+      topicLinks: ['browser-at-interoperability', 'aria-overview'],
+      difficulty: 'hard',
+      tags: ['interoperability', 'triage', 'screen-readers']
+    },
+    {
+      id: 1411,
+      question: "What is the most practical screen reader testing strategy for a team with limited time?",
+      options: [
+        "Test every possible browser and screen reader combination on every release",
+        "Test with a single free screen reader, since all screen readers behave the same",
+        "Test the most-used browser + AT combinations for your audience, such as JAWS+Chrome, NVDA+Chrome/Firefox, and VoiceOver+Safari",
+        "Skip screen reader testing if the automated scan passes"
+      ],
+      correct: 2,
+      explanation: "Coverage should follow real-world usage. Data such as the WebAIM Screen Reader User Survey identifies the most common pairings; testing those recommended combinations catches the issues most users would hit without the impossible cost of testing everything.",
+      wrongExplanations: {
+        0: "Testing every combination is impractical and unnecessary — mismatched pairings that vendors don't test together (e.g., JAWS+Safari) add little value.",
+        1: "Screen readers differ meaningfully in mode behavior, ARIA support, and heuristics — a single AT cannot represent them all.",
+        3: "Automated scans detect only a minority of accessibility issues and cannot evaluate how content is actually announced — they never replace AT testing."
+      },
+      topicLinks: ['browser-at-interoperability', 'screen-reader-testing', 'testing-fundamentals'],
+      difficulty: 'medium',
+      tags: ['testing-strategy', 'screen-readers']
+    },
+    // =============================================
+    // WCAG LIMITATIONS (1412-1414)
+    // =============================================
+    {
+      id: 1412,
+      question: "A design uses an ultra-thin font weight that measures 4.6:1 contrast against its background yet is hard for many low vision users to read. What does this illustrate about WCAG?",
+      options: [
+        "The design fails SC 1.4.3 Contrast (Minimum)",
+        "WCAG's contrast formula is based on color luminance and does not account for font weight — a known limitation of the guidelines",
+        "The design fails SC 1.4.8 Visual Presentation at Level AA",
+        "Contrast requirements do not apply to text styled with custom fonts"
+      ],
+      correct: 1,
+      explanation: "The contrast ratio formula compares the relative luminance of foreground and background colors only. Stroke weight, font legibility, and ornate letterforms are not measured — so a thin or decorative font can pass the math while remaining hard to read. This is a documented gap in WCAG coverage.",
+      wrongExplanations: {
+        0: "4.6:1 exceeds the 4.5:1 minimum for normal text, so SC 1.4.3 passes — that is exactly the point: passing contrast does not guarantee readable text.",
+        2: "SC 1.4.8 Visual Presentation is Level AAA, not AA, and it addresses spacing, width, and justification — it does not regulate font weight either.",
+        3: "Contrast requirements apply to all text regardless of font. The issue is that the formula measures only color, not typeface characteristics."
+      },
+      topicLinks: ['wcag-limitations', 'color-contrast'],
+      difficulty: 'medium',
+      tags: ['wcag-limitations', 'contrast', 'typography']
+    },
+    {
+      id: 1413,
+      question: "A government form uses long, dense, bureaucratic sentences that many users with cognitive disabilities cannot parse. The audit targets WCAG 2.1 Level AA. How should the auditor handle this?",
+      options: [
+        "Flag a failure of SC 3.1.5 Reading Level",
+        "Flag a failure of SC 3.3.2 Labels or Instructions",
+        "Report it as a significant barrier and best-practice recommendation, noting that content complexity is largely uncovered at Level A/AA",
+        "Ignore it, since anything outside WCAG's scope should not appear in an audit report"
+      ],
+      correct: 2,
+      explanation: "Plain language and cognitive load are well-known gaps in WCAG at Level A/AA — SC 3.1.5 Reading Level is AAA and rarely in scope. The barrier is real, so a good auditor reports it, clearly labeled as a best-practice recommendation rather than a conformance failure.",
+      wrongExplanations: {
+        0: "SC 3.1.5 Reading Level is Level AAA. In a Level AA audit it is out of scope and cannot be flagged as a failure.",
+        1: "SC 3.3.2 requires labels or instructions to be provided when content requires user input — it does not regulate the reading complexity of body text.",
+        3: "Audits routinely include best-practice findings precisely because conformance is not the same as usability — they just must be separated from failures."
+      },
+      topicLinks: ['wcag-limitations', 'failures-vs-best-practices', 'cognitive-disabilities'],
+      difficulty: 'hard',
+      tags: ['wcag-limitations', 'cognitive', 'plain-language']
+    },
+    {
+      id: 1414,
+      question: "A website fully conforms to WCAG 2.1 Level AA. What can you conclude about its usability for people with disabilities?",
+      options: [
+        "It may still be difficult or exhausting to use — conformance is a baseline, not a guarantee of usability",
+        "It is guaranteed to be usable by people with all types of disabilities",
+        "It is usable for screen reader users but possibly not for others",
+        "Nothing — WCAG conformance is unrelated to disability access"
+      ],
+      correct: 0,
+      explanation: "Conformance and usability are related but distinct. A minimally conforming site can still impose heavy cognitive load, tedious navigation, or confusing flows. WCAG is the floor; usability testing with people with disabilities reveals what conformance cannot.",
+      wrongExplanations: {
+        1: "No standard can guarantee usability — WCAG's own conformance documentation notes that meeting the criteria does not ensure content is usable by every person with a disability.",
+        2: "There is no basis for singling out screen reader users — conformance raises the baseline for all groups, and usability remains unproven for all groups.",
+        3: "This overcorrects. Conformance is strongly related to access — it removes major barriers — it just does not by itself prove the experience is usable."
+      },
+      topicLinks: ['wcag-limitations', 'usability-testing-pwd', 'usability-concepts'],
+      difficulty: 'easy',
+      tags: ['wcag-limitations', 'usability']
+    },
+    // =============================================
+    // TESTING BY DISABILITY TYPE (1415-1421)
+    // =============================================
+    {
+      id: 1415,
+      question: "Which check belongs specifically on the LOW VISION portion of a test plan?",
+      options: [
+        "Captions accurately reflect dialogue and meaningful sounds",
+        "Content reflows at a width of 320 CSS pixels without two-dimensional scrolling",
+        "Character-key shortcuts can be remapped or turned off",
+        "Live regions announce dynamic updates"
+      ],
+      correct: 1,
+      explanation: "Reflow (SC 1.4.10) is a core low vision check: when zoomed to the equivalent of 320 CSS pixels width, content must reflow into a single column without requiring horizontal scrolling. The low vision cluster also includes 200% text resize, text spacing, contrast, and content on hover/focus.",
+      wrongExplanations: {
+        0: "Caption accuracy belongs to testing for deaf and hard-of-hearing users (SC 1.2.2).",
+        2: "Character-key shortcuts (SC 2.1.4) protect speech-input and keyboard users from accidental activation — part of the input-methods checklist.",
+        3: "Live region announcements (SC 4.1.3) are a screen reader check for blind users, not a low vision magnification concern."
+      },
+      topicLinks: ['testing-by-disability', 'responsive-accessibility'],
+      difficulty: 'easy',
+      tags: ['low-vision', 'reflow', 'testing-by-disability']
+    },
+    {
+      id: 1416,
+      question: "A tester applies a user stylesheet setting line height to 1.5, paragraph spacing to 2x font size, letter spacing to 0.12em, and word spacing to 0.16em. Some button labels get clipped and become unreadable. Which Success Criterion fails?",
+      options: [
+        "SC 1.4.4 Resize Text",
+        "SC 1.4.8 Visual Presentation",
+        "SC 1.4.12 Text Spacing",
+        "SC 1.4.10 Reflow"
+      ],
+      correct: 2,
+      explanation: "SC 1.4.12 Text Spacing (AA) requires no loss of content or functionality when users override text spacing up to exactly these values: line height 1.5x, paragraph spacing 2x, letter spacing 0.12x, and word spacing 0.16x font size. Clipped, overlapping, or truncated text under these overrides is a failure.",
+      wrongExplanations: {
+        0: "SC 1.4.4 covers resizing text up to 200% — the test here changed spacing, not size.",
+        1: "SC 1.4.8 is the Level AAA criterion about visual presentation defaults; the spacing-override test with those specific metrics is the AA criterion 1.4.12.",
+        3: "SC 1.4.10 Reflow is about viewport-width zoom (320 CSS px equivalent), not user-applied spacing overrides."
+      },
+      topicLinks: ['testing-by-disability', 'wcag-perceivable'],
+      difficulty: 'medium',
+      tags: ['low-vision', 'text-spacing']
+    },
+    {
+      id: 1417,
+      question: "A tester sets a desktop browser at 1280px wide to 400% zoom and finds the page requires horizontal scrolling to read paragraphs. Which Success Criterion does this test target?",
+      options: [
+        "SC 1.4.4 Resize Text",
+        "SC 1.4.10 Reflow",
+        "SC 1.3.4 Orientation",
+        "SC 1.4.13 Content on Hover or Focus"
+      ],
+      correct: 1,
+      explanation: "400% zoom at a 1280px-wide window yields an equivalent viewport width of 320 CSS pixels — the exact condition of SC 1.4.10 Reflow. Content must present without loss of information or functionality and without two-dimensional scrolling (vertical-scrolling content must not also need horizontal scrolling).",
+      wrongExplanations: {
+        0: "SC 1.4.4 only requires text to resize up to 200% without loss — the 400%/320px condition is the distinct Reflow criterion. This near-miss distinction is a classic exam trap.",
+        2: "SC 1.3.4 Orientation concerns portrait/landscape lock on mobile devices, not zoom behavior.",
+        3: "SC 1.4.13 governs tooltips and other content appearing on hover or focus — unrelated to zoom and scrolling."
+      },
+      topicLinks: ['testing-by-disability', 'responsive-accessibility'],
+      difficulty: 'hard',
+      tags: ['low-vision', 'reflow', 'zoom']
+    },
+    {
+      id: 1418,
+      question: "A benefits application form logs users out after 15 minutes with no warning, losing their data. Under SC 2.2.1 Timing Adjustable, what must the site provide (assuming no exception applies)?",
+      options: [
+        "A way to turn off, adjust, or extend the time limit — for example, a warning with at least 20 seconds to extend via a simple action",
+        "An automatic save that restores data after re-login",
+        "A time limit of at least 60 minutes",
+        "A CAPTCHA before the session expires to confirm the user is present"
+      ],
+      correct: 0,
+      explanation: "SC 2.2.1 (Level A) requires that users can turn off the time limit, adjust it (up to at least 10 times the default), or extend it — being warned before expiry and given at least 20 seconds to extend with a simple action, extendable at least 10 times. Exceptions exist only for real-time events, essential limits, and limits over 20 hours.",
+      wrongExplanations: {
+        1: "Auto-save is a helpful complementary practice (related to SC 2.2.5 Re-authenticating at AAA), but it does not satisfy 2.2.1, which is about user control over the time limit itself.",
+        2: "WCAG sets no specific minimum duration — any limit under 20 hours triggers the turn off/adjust/extend requirement.",
+        3: "A CAPTCHA adds a barrier rather than control over timing, and CAPTCHAs raise their own accessibility problems."
+      },
+      topicLinks: ['testing-by-disability', 'cognitive-disabilities'],
+      difficulty: 'medium',
+      tags: ['cognitive', 'timeouts', 'wcag-operable']
+    },
+    {
+      id: 1419,
+      question: "A checkout form indicates invalid fields only by turning their borders red. Screen reader users and many cognitively disabled users cannot tell what went wrong. Which Success Criterion is failed?",
+      options: [
+        "SC 3.3.4 Error Prevention (Legal, Financial, Data)",
+        "SC 2.4.6 Headings and Labels",
+        "SC 3.2.4 Consistent Identification",
+        "SC 3.3.1 Error Identification"
+      ],
+      correct: 3,
+      explanation: "SC 3.3.1 Error Identification (Level A) requires that when an input error is automatically detected, the item in error is identified and the error is described to the user in text. A red border alone provides no text description (and also relies on color alone, implicating SC 1.4.1).",
+      wrongExplanations: {
+        0: "SC 3.3.4 requires reversibility, checking, or confirmation for legal/financial/data submissions — it is about preventing consequences, not how detected errors are communicated.",
+        1: "SC 2.4.6 requires headings and labels to be descriptive; the failure here is the missing text description of the error, not the label quality.",
+        2: "SC 3.2.4 requires components with the same functionality to be identified consistently across pages — unrelated to error messaging."
+      },
+      topicLinks: ['testing-by-disability', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['cognitive', 'forms', 'errors']
+    },
+    {
+      id: 1420,
+      question: "Under WCAG 2.2 Level AA, what is the minimum target size required by SC 2.5.8 Target Size (Minimum), barring exceptions such as adequate spacing or inline links?",
+      options: [
+        "16 by 16 CSS pixels",
+        "24 by 24 CSS pixels",
+        "44 by 44 CSS pixels",
+        "48 by 48 CSS pixels"
+      ],
+      correct: 1,
+      explanation: "SC 2.5.8 Target Size (Minimum), new at Level AA in WCAG 2.2, requires pointer targets to be at least 24x24 CSS pixels, with exceptions including sufficient spacing, an equivalent larger control, inline text links, user-agent-controlled, and essential presentations.",
+      wrongExplanations: {
+        0: "16px is not a WCAG target-size threshold at any level.",
+        2: "44x44 is the Level AAA requirement (SC 2.5.5 Target Size, Enhanced) — and also Apple's HIG recommendation — but the AA minimum is 24x24.",
+        3: "48x48dp is Android's design guidance, not a WCAG requirement."
+      },
+      topicLinks: ['testing-by-disability', 'wcag-22-new-criteria'],
+      difficulty: 'medium',
+      tags: ['touch', 'target-size', 'wcag22']
+    },
+    {
+      id: 1421,
+      question: "A training video uses unedited auto-generated captions with frequent recognition errors, no speaker identification, and no indication of important sound effects. A working CC button is present. Does this satisfy SC 1.2.2 Captions (Prerecorded)?",
+      options: [
+        "Yes — captions are provided, which is all the criterion requires",
+        "Yes, as long as a transcript is also linked",
+        "No — captions must accurately convey the dialogue and equivalent auditory information, including speakers and meaningful sounds",
+        "No — auto-generated captions are categorically prohibited by WCAG"
+      ],
+      correct: 2,
+      explanation: "Captions are defined as a text alternative for dialogue AND important non-dialogue audio (speaker identification, meaningful sound effects). Inaccurate auto-captions fail to provide that equivalent, so the criterion is not satisfied. Testing captions means evaluating accuracy and completeness, not just the presence of a CC button.",
+      wrongExplanations: {
+        0: "Mere presence is not enough — captions that do not faithfully convey the audio content do not meet the definition of captions in WCAG.",
+        1: "A transcript does not substitute for captions on synchronized video at Level A/AA — captions must be synchronized with the media.",
+        3: "WCAG does not prohibit auto-generation as a starting point; the issue is the result. Carefully edited auto-captions that become accurate would satisfy the criterion."
+      },
+      topicLinks: ['testing-by-disability', 'auditory-disabilities'],
+      difficulty: 'hard',
+      tags: ['auditory', 'captions', 'multimedia']
+    },
+    // =============================================
+    // TESTING TOOL LANDSCAPE (1422-1425)
+    // =============================================
+    {
+      id: 1422,
+      question: "A development team wants accessibility regressions caught automatically in their build pipeline before any code reaches production. Which tool category fits this need?",
+      options: [
+        "A site-wide scanning and monitoring platform run monthly on production",
+        "A browser extension such as WAVE used by QA after release",
+        "A disability simulator such as NoCoffee",
+        "An automated testing API such as axe-core integrated into unit/integration tests and CI"
+      ],
+      correct: 3,
+      explanation: "Testing APIs and engines like axe-core (e.g., via jest-axe, Playwright/Cypress integrations, or pa11y in CI) run on every build, failing the pipeline when detectable issues are introduced — catching regressions before deployment, the earliest and cheapest phase to fix them.",
+      wrongExplanations: {
+        0: "Site-wide scanners monitor deployed sites — valuable for ongoing oversight of production, but too late to block a regression from shipping.",
+        1: "Browser extensions are interactive, single-page tools for a human tester — they cannot gate an automated build.",
+        2: "Simulators help humans experience approximations of disabilities; they are not automated checks and produce no pass/fail output for a pipeline."
+      },
+      topicLinks: ['automated-testing-tools', 'accessibility-qa-lifecycle'],
+      difficulty: 'medium',
+      tags: ['tools', 'ci-cd', 'automation']
+    },
+    {
+      id: 1423,
+      question: "What is PEAT (Photosensitive Epilepsy Analysis Tool) used to evaluate?",
+      options: [
+        "Whether video and animation content contains flashing that could trigger seizures",
+        "Whether a color palette is distinguishable to color-blind users",
+        "Whether a page is readable under simulated low vision conditions",
+        "Whether captions are synchronized with speech"
+      ],
+      correct: 0,
+      explanation: "PEAT, a free tool from the Trace Research & Development Center, analyzes video and animated content for flash patterns that risk triggering photosensitive seizures — directly supporting evaluation of SC 2.3.1 Three Flashes or Below Threshold.",
+      wrongExplanations: {
+        1: "Color-blindness simulation is the role of tools like Color Oracle, not PEAT.",
+        2: "Low vision simulation (blur, contrast loss, field loss) is what NoCoffee-style simulators provide.",
+        3: "Caption quality and synchronization are assessed manually or with captioning tools — PEAT analyzes flashing, not captions."
+      },
+      topicLinks: ['automated-testing-tools', 'testing-fundamentals'],
+      difficulty: 'easy',
+      tags: ['tools', 'seizures', 'simulators']
+    },
+    {
+      id: 1424,
+      question: "What is the appropriate role of disability simulators such as NoCoffee (low vision) and Color Oracle (color blindness) in a testing program?",
+      options: [
+        "They certify conformance with the visual Success Criteria",
+        "They help testers and designers experience approximations of visual conditions and spot likely problems — but they do not replace conformance testing or feedback from real users",
+        "They replace the need to recruit low vision participants for usability testing",
+        "They automatically fix contrast and color issues they detect"
+      ],
+      correct: 1,
+      explanation: "Simulators build empathy and quickly expose obvious problems (e.g., hue-only coding, low contrast under blur). But they only approximate conditions, cover a fraction of real visual diversity, and produce no conformance evidence — so they supplement, never replace, measurement-based testing and real user feedback.",
+      wrongExplanations: {
+        0: "Conformance to criteria like 1.4.3 is verified by measuring contrast ratios and checking content, not by looking through a simulator.",
+        2: "Real low vision users bring their own strategies, settings, and AT — a sighted tester with a blur filter is not a substitute.",
+        3: "Simulators only alter what the tester sees; they detect nothing and fix nothing in the code."
+      },
+      topicLinks: ['automated-testing-tools', 'usability-testing-pwd'],
+      difficulty: 'medium',
+      tags: ['tools', 'simulators', 'low-vision']
+    },
+    {
+      id: 1425,
+      question: "An agency must keep watch over accessibility across a 50,000-page website and detect newly introduced issues over time. Which tool category is designed for this?",
+      options: [
+        "A bookmarklet such as ANDI run on key pages",
+        "A unit-testing library such as jest-axe",
+        "A site-wide scanning and monitoring platform that crawls the site on a schedule and tracks issues over time",
+        "A screen reader paired with each major browser"
+      ],
+      correct: 2,
+      explanation: "Site-wide scanners and monitoring platforms crawl large sites on a schedule, aggregate automatically detectable issues, track trends, and alert on regressions — the only practical way to maintain oversight across tens of thousands of pages. Page-level and manual methods then target what monitoring surfaces.",
+      wrongExplanations: {
+        0: "ANDI (the free SSA bookmarklet) is excellent for inspecting one page at a time in the browser — it cannot crawl or monitor 50,000 pages.",
+        1: "jest-axe tests components during development in the codebase's own test suite — it does not observe the deployed production site.",
+        3: "Screen reader testing is essential but manual and slow — it is for evaluating representative pages and flows, not continuous site-wide monitoring."
+      },
+      topicLinks: ['automated-testing-tools', 'accessibility-qa-lifecycle', 'wcag-em'],
+      difficulty: 'medium',
+      tags: ['tools', 'monitoring', 'scanning']
+    },
+    // =============================================
+    // SCREEN READER MODES & NAVIGATION (1426-1429)
+    // =============================================
+    {
+      id: 1426,
+      question: "While reading a web page in browse (virtual) mode with NVDA or JAWS, what does pressing the letter H do?",
+      options: [
+        "Types the letter H into the page",
+        "Opens the browser history",
+        "Activates the focused link",
+        "Moves to the next heading on the page"
+      ],
+      correct: 3,
+      explanation: "In browse/virtual mode the screen reader intercepts keystrokes as quick-navigation commands: H jumps to the next heading (1-6 jump to specific levels), L to the next list, T to the next table, F to the next form field, B to the next button. This is why a sound heading structure matters so much.",
+      wrongExplanations: {
+        0: "Letters are only typed into the page in forms/focus mode — in browse mode the screen reader consumes them as navigation commands.",
+        1: "Browser history shortcuts involve modifier keys (e.g., Ctrl+H); the single letter H is captured by the screen reader for heading navigation.",
+        2: "Links are activated with Enter; H is the heading quick-nav key."
+      },
+      topicLinks: ['screen-reader-modes', 'screen-reader-testing'],
+      difficulty: 'easy',
+      tags: ['screen-readers', 'keystrokes', 'browse-mode']
+    },
+    {
+      id: 1427,
+      question: "A developer adds role='application' to a content-heavy web page to 'improve the experience.' What actually happens for screen reader users?",
+      options: [
+        "Browse mode is disabled — quick-nav keys and reading commands stop working, and the author becomes responsible for implementing all keyboard interaction",
+        "The screen reader switches to a higher-quality voice",
+        "The page loads faster because the accessibility tree is skipped",
+        "Headings and landmarks are announced more verbosely"
+      ],
+      correct: 0,
+      explanation: "role='application' tells the screen reader to drop browse/virtual mode and pass all keystrokes to the page. Users lose heading navigation, element lists, and reading commands — and unless the author has implemented complete custom keyboard handling, the page becomes nearly unusable. It is almost never appropriate for ordinary web content.",
+      wrongExplanations: {
+        1: "ARIA roles have no effect on speech synthesis voices.",
+        2: "The accessibility tree is still built; role='application' changes the interaction mode, not performance.",
+        3: "The opposite — within an application region the screen reader stops providing its document-reading conveniences, including structural navigation."
+      },
+      topicLinks: ['screen-reader-modes', 'aria-roles'],
+      difficulty: 'medium',
+      tags: ['screen-readers', 'aria', 'application-mode']
+    },
+    {
+      id: 1428,
+      question: "A screen reader user is arrowing through a page and then Tabs into a search field, where typing suddenly enters text instead of triggering navigation commands. What explains this?",
+      options: [
+        "The page uses JavaScript to capture all keyboard input",
+        "The screen reader automatically switched from browse mode to forms (focus) mode when focus entered an editable field",
+        "The screen reader crashed and restarted in a safe mode",
+        "The search field uses role='search', which disables the screen reader"
+      ],
+      correct: 1,
+      explanation: "JAWS and NVDA automatically switch from browse/virtual mode to forms/focus mode when focus lands on an editable field or interactive widget, passing keystrokes through to the page so the user can type. Users can also toggle modes manually (e.g., NVDA+Space). Understanding this switch is essential for diagnosing 'my quick-nav keys stopped working' reports.",
+      wrongExplanations: {
+        0: "No page script is needed — mode switching is standard screen reader behavior driven by the role of the focused element.",
+        2: "Mode switching is normal, expected behavior, often signaled by an earcon (sound), not a malfunction.",
+        3: "role='search' is a landmark role that aids navigation; it does not disable anything."
+      },
+      topicLinks: ['screen-reader-modes', 'form-accessibility'],
+      difficulty: 'medium',
+      tags: ['screen-readers', 'forms-mode']
+    },
+    {
+      id: 1429,
+      question: "Using VoiceOver on iOS or TalkBack on Android, how does a user move to the next item on screen and then activate it?",
+      options: [
+        "Swipe right to move to the next item, then double-tap to activate it",
+        "Swipe up to move to the next item, then long-press to activate it",
+        "Triple-tap to move to the next item, then swipe left to activate it",
+        "Shake the device to move forward, then tap once to activate"
+      ],
+      correct: 0,
+      explanation: "Both major mobile screen readers share the same core gestures: swipe right moves to the next item, swipe left to the previous, and double-tap activates the current item. Users can also explore by touch, dragging a finger to hear what is under it.",
+      wrongExplanations: {
+        1: "Swipe up/down typically changes or applies the reading granularity (rotor/reading controls), and long-press is not the standard activation gesture.",
+        2: "Triple-tap and swipe-left have other functions (swipe left moves backward); neither is the next/activate pair.",
+        3: "Shaking the device is not a navigation gesture in either screen reader — and motion-based controls are exactly what SC 2.5.4 requires alternatives for."
+      },
+      topicLinks: ['screen-reader-modes', 'screen-readers'],
+      difficulty: 'easy',
+      tags: ['mobile', 'gestures', 'screen-readers']
+    },
+    // =============================================
+    // USABILITY TESTING WITH PWD (1430-1431)
+    // =============================================
+    {
+      id: 1430,
+      question: "A team runs a usability study with one expert JAWS user, who completes every task quickly, and concludes the product 'works for screen reader users.' What is the main flaw in this conclusion?",
+      options: [
+        "JAWS is no longer a widely used screen reader",
+        "Expert users should never be included in usability studies",
+        "One session can only validate conformance, not usability",
+        "Disability groups are internally diverse — one expert participant cannot represent users with different skill levels, AT, settings, and strategies"
+      ],
+      correct: 3,
+      explanation: "Two screen reader users can have radically different experiences: an expert navigating by landmarks at high speech rate versus a recent AT learner reading linearly with defaults. Skill, screen reader choice, browser, verbosity settings, and co-occurring disabilities all vary — generalizing from one participant misrepresents the group.",
+      wrongExplanations: {
+        0: "JAWS remains one of the most widely used desktop screen readers — the flaw is the sample, not the tool.",
+        1: "Experts are valuable participants; the problem is relying ONLY on one expert and generalizing to everyone.",
+        2: "Backwards on both counts: usability studies measure usability, and no usability session of any size validates conformance."
+      },
+      topicLinks: ['usability-testing-pwd', 'disability-user-strategies'],
+      difficulty: 'medium',
+      tags: ['user-testing', 'diversity']
+    },
+    {
+      id: 1431,
+      question: "A page has a working skip link and proper landmarks, and every control is keyboard operable — it passes the relevant WCAG criteria. In usability sessions, keyboard users still abandon a booking task that requires over 100 Tab presses through a dense form. How should this finding be handled?",
+      options: [
+        "Flag a failure of SC 2.1.1 Keyboard, since the task is too hard with a keyboard",
+        "Report it as a serious usability finding with redesign recommendations, while noting it is not a WCAG conformance failure",
+        "Flag a failure of SC 2.4.1 Bypass Blocks, since users want to bypass the form",
+        "Discard the finding because the page conforms"
+      ],
+      correct: 1,
+      explanation: "This is the classic illustration that conformance is not usability: everything is technically operable (2.1.1 passes) and repeated blocks are bypassable (2.4.1 passes), yet the experience is exhausting enough that users fail. It belongs in the report as a high-impact usability finding, clearly separated from conformance failures.",
+      wrongExplanations: {
+        0: "SC 2.1.1 requires functionality to be operable through a keyboard interface — it says nothing about how many keystrokes are acceptable. The page meets the normative text.",
+        2: "SC 2.4.1 covers bypassing blocks of content repeated across multiple pages (like site navigation) — a skip link is present, and a unique form is not 'repeated blocks.'",
+        3: "Discarding real evidence that users cannot complete a core task defeats the purpose of testing — usability findings matter even when no criterion fails."
+      },
+      topicLinks: ['usability-testing-pwd', 'wcag-limitations', 'failures-vs-best-practices'],
+      difficulty: 'hard',
+      tags: ['user-testing', 'keyboard', 'conformance-vs-usability']
+    },
+    // =============================================
+    // FAILURES VS BEST PRACTICES (1432)
+    // =============================================
+    {
+      id: 1432,
+      question: "An auditor reviews a long article in a WCAG 2.1 AA audit. Section titles are visually styled as bold, enlarged text but are not marked up as headings. What is the correct determination?",
+      options: [
+        "Failure of SC 2.4.6 Headings and Labels, because the headings are not descriptive",
+        "No failure — WCAG does not require pages to use headings",
+        "Failure of SC 2.4.10 Section Headings, because sections lack headings",
+        "Failure of SC 1.3.1 Info and Relationships, because a visual heading structure exists that is not programmatically determinable"
+      ],
+      correct: 3,
+      explanation: "When text visually functions as a heading, that structural relationship must be programmatically conveyed (e.g., h1-h6). Styling text to look like a heading without heading markup is a documented failure of SC 1.3.1 (F2). By contrast, a page with NO headings at all — visual or structural — fails nothing, since no criterion at A/AA requires headings to exist.",
+      wrongExplanations: {
+        0: "SC 2.4.6 only requires headings and labels, where they exist, to be descriptive — the issue here is missing programmatic structure, which is 1.3.1 territory.",
+        1: "That reasoning applies only when there is no visual heading structure either. Here the design clearly presents headings visually, so the relationship must be in the markup.",
+        2: "SC 2.4.10 Section Headings is Level AAA and out of scope in an AA audit — citing it would be an auditing error."
+      },
+      topicLinks: ['failures-vs-best-practices', 'semantic-html'],
+      difficulty: 'hard',
+      tags: ['auditing', 'headings', 'success-criteria-mapping']
     }
   ]
 };

--- a/src/data/questions/was-domain3.js
+++ b/src/data/questions/was-domain3.js
@@ -816,6 +816,369 @@ export const wasDomain3 = {
       topicLinks: ['accessibility-qa-lifecycle', 'maturity-models', 'procurement-accessibility'],
       difficulty: 'hard',
       tags: ['organizational', 'maturity-models', 'lifecycle', 'remediation']
+    },
+    // =============================================
+    // PROCUREMENT EXPERT ROLE & STAKEHOLDER COMMUNICATION (1501-1518)
+    // =============================================
+    {
+      id: 1501,
+      question: "A software vendor hires an accessibility expert to help them compete for government contracts. Which set of activities fits the expert's role on the VENDOR side of procurement?",
+      options: [
+        "Auditing the vendor's existing systems, remedying defects, creating an ACR, and responding to tender questions about accessibility",
+        "Drafting the government agency's RFP requirements and scoring competing bids",
+        "Approving the vendor's products for sale under Section 508",
+        "Writing the contract terms the purchasing agency will impose on the vendor"
+      ],
+      correct: 0,
+      explanation: "Accessibility experts can assist vendors by auditing existing systems, remedying defects, creating Accessibility Conformance Reports, and responding to tender questions regarding accessibility. These activities prepare the vendor to demonstrate and improve the accessibility of its products credibly.",
+      wrongExplanations: {
+        1: "Drafting RFP requirements and evaluating bids is the expert's role when working for the PURCHASER, not the vendor. An expert working for a bidding vendor would have a conflict of interest scoring the competition.",
+        2: "No individual expert 'approves' products under Section 508 — there is no certification authority. Section 508 conformance is documented (e.g., via ACRs) and verified by purchasing agencies.",
+        3: "Suggesting contract wording on accessibility is a service experts provide to purchasers, who impose the terms. The vendor side responds to those requirements rather than writing them."
+      },
+      topicLinks: ['procurement-expert-role', 'vpat'],
+      difficulty: 'easy',
+      tags: ['procurement', 'expertise', 'vendors']
+    },
+    {
+      id: 1502,
+      question: "A university is preparing a Request for Proposal (RFP) for a new learning management system. What is the accessibility expert's MOST useful contribution at this stage?",
+      options: [
+        "Waiting until a product is selected, then auditing it for accessibility defects",
+        "Supplying a list of suitable accessibility questions for inclusion in the tender documents and advising which procurement standard (e.g., EN 301 549 or Section 508) to reference",
+        "Requiring that all bidders demonstrate WCAG 2.1 Level AAA conformance",
+        "Recommending the university build the system in-house to avoid procurement entirely"
+      ],
+      correct: 1,
+      explanation: "At the RFP stage, accessibility experts provide purchasers with suitable questions for inclusion in tender documents and RFPs, plus advice on ICT procurement standards such as EN 301 549 and Section 508. Asking the right questions before vendors respond is what lets the organization compare accessibility credibly during selection.",
+      wrongExplanations: {
+        0: "Auditing only after selection forfeits the organization's maximum leverage. Accessibility should be built into the tender documents so it influences which product is chosen.",
+        2: "Requiring Level AAA is unrealistic — WCAG itself does not recommend requiring AAA for entire sites, and very few products fully support even all A/AA criteria. Procurement standards reference Level AA-based requirements.",
+        3: "Building in-house does not avoid the accessibility question — it just moves it to development. Procurement with strong accessibility requirements is a legitimate, often more practical path."
+      },
+      topicLinks: ['procurement-expert-role', 'procurement-accessibility'],
+      difficulty: 'easy',
+      tags: ['procurement', 'rfp', 'expertise']
+    },
+    {
+      id: 1503,
+      question: "Two vendors respond to a tender. Vendor A submits an in-house ACR claiming 'Supports' on every single criterion. Vendor B submits an ACR prepared by an independent accessibility consultancy showing several 'Partially Supports' entries with detailed remarks. How should the evaluating expert read this?",
+      options: [
+        "Vendor A is the safer choice because its report shows full conformance",
+        "Vendor B's report should be treated with more suspicion because it admits defects",
+        "Vendor B's report is more credible — independently produced ACRs are preferable, and very few products genuinely support every criterion, so a perfect in-house report warrants verification through direct testing",
+        "Both reports are equally reliable because the VPAT is a standardized template"
+      ],
+      correct: 2,
+      explanation: "The BoK states it is preferable that vendors use an independent accessibility professional to create their ACR rather than producing it in-house, and that in practice very few products fully support every single criterion. A perfect self-reported scorecard is a red flag to verify with direct product testing, while honest 'Partially Supports' entries with remarks give useful information about where to focus the review.",
+      wrongExplanations: {
+        0: "A blanket 'Supports' claim from an in-house report is more likely to reflect optimistic self-assessment than genuine full conformance. Claims should be verified by testing, not taken at face value.",
+        1: "Documented defects with remarks indicate a more rigorous evaluation, not a worse product. Transparency about partial support is expected in credible ACRs.",
+        3: "The template standardizes the format, not the quality or honesty of the assessment. Who performed the evaluation and how thoroughly still matters enormously."
+      },
+      topicLinks: ['procurement-expert-role', 'vpat'],
+      difficulty: 'medium',
+      tags: ['procurement', 'vpat', 'acr', 'verification']
+    },
+    {
+      id: 1504,
+      question: "An accessibility expert is asked to 'suggest contract wording regarding accessibility' for a software purchase. What should that wording accomplish?",
+      options: [
+        "State that the vendor 'values accessibility and will make reasonable efforts where feasible'",
+        "Make accessibility commitments binding — e.g., conformance obligations, defect remediation timelines, and consequences for non-compliance",
+        "Transfer all legal liability for accessibility complaints to the end users",
+        "Guarantee the product will never have any accessibility defects"
+      ],
+      correct: 1,
+      explanation: "The point of contract wording on accessibility is to convert vendor claims into binding accessibility commitments — one of the BoK's named mitigation strategies. Effective wording covers the conformance standard required, timelines for remediating known and future defects, and what happens if the vendor fails to deliver.",
+      wrongExplanations: {
+        0: "Vague aspirational language ('reasonable efforts where feasible') is unenforceable. It gives the purchaser no leverage when defects surface after signing.",
+        2: "Liability for an organization's inaccessible services cannot be shifted onto the very users who are excluded. Contract wording allocates responsibility between purchaser and vendor.",
+        3: "No vendor can guarantee zero defects, and demanding it produces either refusal or a meaningless promise. Binding commitments paired with remediation processes are the realistic mechanism."
+      },
+      topicLinks: ['procurement-expert-role', 'procurement-accessibility'],
+      difficulty: 'medium',
+      tags: ['procurement', 'contracts', 'mitigation']
+    },
+    {
+      id: 1505,
+      question: "A procured product's ACR lists 'Partially Supports' for SC 2.1.1 Keyboard. What does this conformance level mean, and what should the purchasing team do with that information?",
+      options: [
+        "The majority of the product's functionality fails the criterion; the product must be rejected",
+        "Some functionality of the product does not meet the criterion; the team should examine those areas during product review to judge the real impact on their users",
+        "The criterion is not relevant to this product, so the entry can be ignored",
+        "The product meets the criterion through equivalent facilitation, so no follow-up is needed"
+      ],
+      correct: 1,
+      explanation: "'Partially Supports' means some functionality of the product does not meet the criterion. The BoK frames such entries as helpful information about what areas to pay attention to during product reviews — the team should investigate which functionality is affected and how severely it would impact their actual users and tasks.",
+      wrongExplanations: {
+        0: "'The majority of product functionality does not meet the criterion' is the definition of 'Does Not Support', a more severe level. And even genuine defects trigger investigation and mitigation, not automatic rejection.",
+        2: "'Not Applicable' is the level for criteria that are not relevant to the product. 'Partially Supports' explicitly indicates a real, relevant gap.",
+        3: "Equivalent facilitation falls under 'Supports' — functionality that meets the criterion via at least one method. 'Partially Supports' signals known gaps that need follow-up."
+      },
+      topicLinks: ['procurement-expert-role', 'vpat'],
+      difficulty: 'medium',
+      tags: ['procurement', 'vpat', 'acr', 'conformance-levels']
+    },
+    {
+      id: 1506,
+      question: "A procurement officer announces: 'To be safe, we will only consider products whose ACR shows Supports for every single criterion.' Why is this policy impractical?",
+      options: [
+        "Because ACRs do not actually list individual criteria, only an overall score",
+        "Because in practice very few products fully support every WCAG or other criterion — the policy would eliminate nearly the whole market and reward dishonest self-reporting over transparent reporting",
+        "Because WCAG prohibits using conformance reports in purchasing decisions",
+        "Because 'Supports' is only available as a rating in the Section 508 edition of the VPAT"
+      ],
+      correct: 1,
+      explanation: "The BoK is explicit: ideally every criterion would be supported, but in practice very few products fully support every single WCAG or other criterion. A 'perfect ACR only' policy would disqualify almost everything — and perversely favor vendors who overstate conformance in-house over vendors who report honestly. Better practice: compare products realistically, weigh partial support by user impact, and mitigate remaining defects contractually.",
+      wrongExplanations: {
+        0: "ACRs are precisely a criterion-by-criterion reporting table (criteria, conformance level, remarks). There is no single overall score.",
+        2: "Nothing in WCAG prohibits this — conformance reports exist largely to inform purchasing decisions. The problem is the unrealistic threshold, not the use of ACRs.",
+        3: "All VPAT editions (508, EU, WCAG, INT) use the same conformance levels, including 'Supports'."
+      },
+      topicLinks: ['procurement-expert-role', 'vpat'],
+      difficulty: 'hard',
+      tags: ['procurement', 'vpat', 'acr', 'evaluation']
+    },
+    {
+      id: 1507,
+      question: "In an ACR, a product's audio player cannot be operated with standard keyboard commands, but the vendor provides a fully documented, equally capable keyboard-accessible alternative interface for the same functions. Which conformance level can the vendor legitimately report for the keyboard criterion?",
+      options: [
+        "Does Not Support, because the primary interface fails",
+        "Partially Supports, because only one of the two interfaces meets the criterion",
+        "Supports, because the functionality has at least one method that meets the criterion — equivalent facilitation counts",
+        "Not Applicable, because keyboard access is optional for media players"
+      ],
+      correct: 2,
+      explanation: "The VPAT definition of 'Supports' is that the product's functionality has at least one method that meets the criterion without known defects OR with equivalent facilitation. An alternative method providing equivalent access to the same functionality allows a 'Supports' rating, though the remarks column should explain how.",
+      wrongExplanations: {
+        0: "'Does Not Support' means the majority of product functionality does not meet the criterion. Here the functionality IS available through an accessible method.",
+        1: "'Partially Supports' would apply if some functionality had no accessible method at all. The conformance levels evaluate whether functionality is achievable accessibly, not whether every interface variant passes.",
+        3: "'Not Applicable' means the criterion is not relevant to the product. Keyboard operability is clearly relevant to an interactive media player."
+      },
+      topicLinks: ['procurement-expert-role', 'vpat'],
+      difficulty: 'hard',
+      tags: ['procurement', 'vpat', 'acr', 'equivalent-facilitation']
+    },
+    {
+      id: 1508,
+      question: "An organization's newly procured HR system has a defect that prevents screen reader users from submitting expense reports. The vendor's fix is six months away. What does the BoK recommend the organization put in place NOW?",
+      options: [
+        "Nothing — the remediation roadmap already covers the issue",
+        "An alternative access plan, so affected users have another way to complete the task while the defect is being fixed",
+        "A waiver exempting screen reader users from submitting expense reports",
+        "An immediate switch to a different HR system"
+      ],
+      correct: 1,
+      explanation: "Among the BoK's mitigation strategies for known defects in procured products is 'putting in place an alternative access plan for users.' A roadmap addresses the future; the alternative access plan (for example, an accessible form, email submission, or staffed assistance) addresses the exclusion happening right now.",
+      wrongExplanations: {
+        0: "A roadmap commits the vendor to a future fix but does nothing for users blocked today. Mitigation strategies are meant to be combined — roadmap plus interim access.",
+        2: "Exempting users from a work task doesn't give them access — it sidelines them. Employees need an equivalent way to do their job, not permission to skip it.",
+        3: "Switching systems mid-contract is rarely feasible (cost, contracts, migration) and a replacement system would have its own defects. Mitigation manages the gap pragmatically."
+      },
+      topicLinks: ['procurement-expert-role', 'procurement-accessibility'],
+      difficulty: 'medium',
+      tags: ['procurement', 'mitigation', 'alternative-access']
+    },
+    {
+      id: 1509,
+      question: "A vendor committed to a remediation roadmap a year ago but has repeatedly missed its deadlines. The annual contract renewal is approaching. What does the BoK suggest?",
+      options: [
+        "Renew as usual — the roadmap legally obligates the vendor regardless of renewals",
+        "Monitor vendor performance on defect management and make accessibility performance a factor in the renewal negotiation, where the organization regains leverage",
+        "Stop tracking the defects since the vendor owns the roadmap",
+        "Publicly report the vendor to a standards body that enforces VPAT accuracy"
+      ],
+      correct: 1,
+      explanation: "Two of the BoK's mitigation strategies apply directly: monitoring vendor performance in relation to defect management, and considering accessibility performance during contract negotiations and product renewals. Renewal is one of the few moments after purchase when the purchaser's leverage returns — missed roadmap deadlines should carry consequences there.",
+      wrongExplanations: {
+        0: "A roadmap is only as strong as the contract behind it, and automatic renewal squanders the organization's main recurring leverage point. Performance should inform renewal terms.",
+        2: "The vendor executes the roadmap, but the purchaser must monitor performance — unmonitored commitments are routinely deprioritized.",
+        3: "No standards body enforces VPAT accuracy — VPATs are voluntary self-reports. Leverage comes from the contractual relationship, not external enforcement."
+      },
+      topicLinks: ['procurement-expert-role', 'procurement-accessibility'],
+      difficulty: 'medium',
+      tags: ['procurement', 'vendor-management', 'contracts']
+    },
+    {
+      id: 1510,
+      question: "After product testing reveals several accessibility defects in software the organization still intends to buy, what is the FIRST artifact the accessibility expert should obtain from the vendor?",
+      options: [
+        "A press release announcing the vendor's commitment to accessibility",
+        "A remediation roadmap describing how and when the known accessibility issues will be addressed",
+        "A refund schedule for users with disabilities",
+        "A new VPAT omitting the criteria the product fails"
+      ],
+      correct: 1,
+      explanation: "The first of the BoK's defect-mitigation strategies is obtaining a roadmap for addressing known accessibility issues. The roadmap turns vague intentions into specific, trackable commitments — which can then be made binding in the contract and monitored over time.",
+      wrongExplanations: {
+        0: "Public statements of commitment are marketing, not mitigation. They create no specific, trackable obligation to fix the identified defects.",
+        2: "Refunds compensate; they don't provide access. The goal of mitigation is to get the defects fixed and provide alternative access in the meantime.",
+        3: "Omitting failed criteria from a VPAT is misrepresentation, not mitigation. An honest ACR documents the gaps that the roadmap then addresses."
+      },
+      topicLinks: ['procurement-expert-role', 'procurement-accessibility'],
+      difficulty: 'easy',
+      tags: ['procurement', 'mitigation', 'roadmap']
+    },
+    {
+      id: 1511,
+      question: "What is Policy Driven Adoption for Accessibility (PDAA)?",
+      options: [
+        "A W3C technical specification for accessible policy documents",
+        "An initiative by NASCIO (the National Association of State Chief Information Officers) that helps procurement organizations choose vendors who can meet accessibility requirements",
+        "A US federal law requiring states to adopt Section 508",
+        "An automated testing tool that scans vendor products for WCAG failures"
+      ],
+      correct: 1,
+      explanation: "PDAA — Policy Driven Adoption for Accessibility — is a NASCIO initiative and one of the two publicly available, free maturity models that specifically address procurement. It helps procurement organizations select vendors capable of meeting accessibility requirements by examining the maturity of vendors' accessibility policies and practices.",
+      wrongExplanations: {
+        0: "PDAA is not a W3C specification and is not about document formats. The W3C's contribution in this space is the Accessibility Maturity Model, which includes a procurement dimension.",
+        2: "PDAA is a voluntary initiative from NASCIO, an association of state CIOs — not legislation. Section 508 itself applies to US federal agencies.",
+        3: "PDAA is a policy/maturity framework for evaluating vendors, not a scanning tool. It assesses organizational practices rather than running technical tests."
+      },
+      topicLinks: ['procurement-expert-role', 'maturity-models'],
+      difficulty: 'medium',
+      tags: ['procurement', 'pdaa', 'maturity-models']
+    },
+    {
+      id: 1512,
+      question: "An organization wants to (a) assess how well its OWN purchasing processes embed accessibility, and (b) evaluate whether prospective VENDORS can meet accessibility requirements. Which maturity tools map to which goal?",
+      options: [
+        "(a) PDAA for its own processes; (b) the W3C maturity model for vendors",
+        "(a) The W3C Accessibility Maturity Model's procurement dimension for its own sourcing, negotiation, and selection practices; (b) PDAA for evaluating vendors",
+        "Both goals require the VPAT, since it is the only procurement assessment tool",
+        "Neither goal can use a maturity model; maturity models only measure website conformance"
+      ],
+      correct: 1,
+      explanation: "The W3C maturity model's procurement dimension assesses the organization's own procurement lifecycle — its use of accessibility processes, criteria, contract language, and decision-making in sourcing, negotiating, and selecting goods and services. PDAA, the NASCIO initiative, is oriented toward helping procurement organizations choose vendors who can meet accessibility requirements.",
+      wrongExplanations: {
+        0: "This reverses the two tools. PDAA is the vendor-facing instrument; the W3C procurement dimension is the self-assessment of the purchasing organization's own practices.",
+        2: "A VPAT/ACR documents one product's conformance — it assesses neither organizational process maturity nor a vendor's overall capability and policies.",
+        3: "Maturity models measure organizational capability, which is exactly what both goals require. Website conformance is measured by technical evaluation, not maturity models."
+      },
+      topicLinks: ['procurement-expert-role', 'maturity-models'],
+      difficulty: 'hard',
+      tags: ['procurement', 'pdaa', 'maturity-models', 'w3c']
+    },
+    {
+      id: 1513,
+      question: "An accessibility consultant delivers a flawless 80-page audit report, but six months later almost nothing has been fixed. Developers say they never understood what to change, and managers say they never knew why it mattered. Which BoK principle was violated?",
+      options: [
+        "The audit should have used automated tools to find more issues",
+        "The right stakeholders must be made aware, educated, and included in implementation recommendations",
+        "The report should have been longer and more technically detailed",
+        "Remediation should always be outsourced to the auditing consultant"
+      ],
+      correct: 1,
+      explanation: "The BoK stresses being able to communicate the purpose, approach, and strategy of remediation, and the importance of making the right stakeholders aware, educated, and included in implementation recommendations. A report that informs no one and includes no one produces no remediation, regardless of its technical quality.",
+      wrongExplanations: {
+        0: "Finding more issues would make the unread report longer. The failure here is communication and stakeholder engagement, not detection coverage.",
+        2: "More length and density would worsen the problem. Different audiences need appropriately framed information — precise fixes for developers, impact and risk for managers.",
+        3: "Outsourcing fixes can be a tactic, but the organization still needs informed, included stakeholders to sustain accessibility. The BoK principle is about engagement, not who writes the code."
+      },
+      topicLinks: ['stakeholder-communication', 'remediation-strategies'],
+      difficulty: 'easy',
+      tags: ['communication', 'stakeholders', 'remediation']
+    },
+    {
+      id: 1514,
+      question: "An accessibility specialist must present the same audit findings to the development team and then to the executive steering committee. How should the framing differ?",
+      options: [
+        "Use the identical slide deck for both, since the findings are the same",
+        "Developers: precisely where the problems are, what they are, and how to fix them. Executives: user impact, legal risk, and cost-benefit of remediation",
+        "Developers: legal risk statistics. Executives: code snippets showing correct ARIA usage",
+        "Tell executives only the good news so funding is not jeopardized"
+      ],
+      correct: 1,
+      explanation: "The BoK says that when communicating issues and recommendations, it is important to inform the developer precisely about where the problems are, what the problems are, and how to fix them. Decision-makers, by contrast, act on user impact, legal risk, and cost-benefit — the prioritization language of Domain 3A. Same findings, audience-appropriate framing.",
+      wrongExplanations: {
+        0: "Identical framing fails both audiences: executives drown in technical detail they can't act on, and developers get strategy slides without the precise locations and fixes they need.",
+        2: "This is exactly backwards. Code-level guidance belongs with the people writing code; risk and investment framing belongs with the people allocating budget.",
+        3: "Hiding problems from decision-makers prevents informed prioritization and undermines trust — and unaddressed legal risk eventually surfaces on its own terms."
+      },
+      topicLinks: ['stakeholder-communication', 'remediation-prioritization'],
+      difficulty: 'medium',
+      tags: ['communication', 'stakeholders', 'reporting']
+    },
+    {
+      id: 1515,
+      question: "An audit of a small nonprofit's donation site finds the custom date picker is unusable with screen readers. The IDEAL fix is rebuilding it on an accessible component library, but the nonprofit has one part-time developer and a fundraising deadline in three weeks. What distinguishes a defensible 'good enough' recommendation here?",
+      options: [
+        "It achieves the same end result as the ideal solution while respecting the project's environment, target groups, and resources — e.g., replacing the widget with a native input or plain text field users can complete now",
+        "It postpones all changes until the organization can afford the ideal rebuild",
+        "It is whatever the developer can finish fastest, regardless of whether users can complete the task",
+        "It documents the issue in the accessibility statement so users know the date picker is broken"
+      ],
+      correct: 0,
+      explanation: "The BoK asks specialists to characterize and differentiate the ideal/best solution from the 'good enough' solution, respecting the particular project, its environment, intended target groups, and resources. A simpler control that lets every user complete the donation before the deadline is good enough — it removes the barrier within real constraints, while the ideal rebuild can be planned for later.",
+      wrongExplanations: {
+        1: "Postponing everything leaves donors with disabilities blocked through the organization's most critical period. Feasible interim fixes exist and should be applied.",
+        2: "'Good enough' is judged against users completing the task, not against developer convenience. A fast change that still blocks screen reader users solves nothing.",
+        3: "Documenting a barrier is transparency, not remediation. An accessibility statement does not help a donor who still cannot enter a date."
+      },
+      topicLinks: ['stakeholder-communication', 'remediation-strategies'],
+      difficulty: 'medium',
+      tags: ['good-enough', 'remediation', 'feasibility']
+    },
+    {
+      id: 1516,
+      question: "A site's main navigation is fully keyboard-operable but forces users through dozens of tab stops before reaching the content, and every image has technically present but extremely verbose alt text. The site passes WCAG conformance testing. What should a good auditor do?",
+      options: [
+        "Nothing — if it conforms to WCAG, there is no issue to report",
+        "Report both as WCAG conformance failures, since they harm users",
+        "Recognize that minimal conformance can still be difficult to use, and recommend better practices (e.g., reducing tab stops, concise alt text) clearly labeled as recommendations rather than failures",
+        "Withhold the conformance pass until the usability problems are fixed"
+      ],
+      correct: 2,
+      explanation: "These are the BoK's own examples: navigation that is keyboard-operable but has dozens of tab stops, and alt text that is too verbose, technically meet WCAG while producing a poor experience. Beyond normative failures, a good auditor recognizes deficiencies that are not strictly failures and recommends a better practice for a more usable result — while keeping the conformance/best-practice distinction explicit.",
+      wrongExplanations: {
+        0: "Conformance is the floor, not the ceiling. The BoK explicitly warns that a minimally conforming site can still be difficult to use, and auditors should surface that.",
+        1: "Flagging conforming content as failures destroys the auditor's credibility and misstates the standard. A failure should be flagged only when content clearly fails the normative criterion.",
+        3: "An auditor cannot 'withhold' conformance that the content factually meets. The honest report is: conforms, with clearly labeled usability recommendations."
+      },
+      topicLinks: ['stakeholder-communication', 'failures-vs-best-practices'],
+      difficulty: 'hard',
+      tags: ['usability', 'conformance', 'best-practices', 'auditing']
+    },
+    {
+      id: 1517,
+      question: "A legacy intranet has hundreds of accessibility defects rooted in its templates, but employees with disabilities are blocked TODAY from requesting leave and viewing payslips. Which remediation strategy does the BoK describe as the common practical pattern?",
+      options: [
+        "A hybrid approach: immediately remediate the critical blocking issues while developing a longer-term plan for a comprehensive rewrite",
+        "Freeze all fixes until the full redesign budget is approved, to avoid duplicated work",
+        "Fix every defect in severity order and cancel any redesign plans",
+        "Rewrite the entire intranet first, since template-level defects make spot fixes pointless"
+      ],
+      correct: 0,
+      explanation: "The BoK states that in practice a hybrid approach is often used: immediate remediation addresses critical issues while a longer-term plan is developed for a comprehensive rewrite to ensure sustainable accessibility. Users get unblocked now; the systemic template problems get solved properly later.",
+      wrongExplanations: {
+        1: "Freezing fixes leaves employees unable to perform essential job tasks for the entire planning-and-budget cycle. Critical blockers warrant immediate remediation even if some work is later superseded.",
+        2: "Fixing hundreds of defects one by one in old, template-driven code may cost more than the rewrite while leaving the architecture fragile. Widespread template-level defects are precisely when a rewrite is warranted.",
+        3: "Spot fixes to critical blockers are not pointless — they restore access to essential tasks during the months a rewrite takes. Sequencing the rewrite first abandons users in the meantime."
+      },
+      topicLinks: ['stakeholder-communication', 'remediation-strategies'],
+      difficulty: 'medium',
+      tags: ['hybrid-approach', 'remediation', 'redesign']
+    },
+    {
+      id: 1518,
+      question: "A developer disputes an audit finding, arguing their custom disclosure widget is 'fine because WCAG doesn't say exactly how to code it.' The auditor is confident the widget fails SC 4.1.2 but the case is borderline. Which resources does the BoK say can settle whether this is a normative failure or a best-practice recommendation?",
+      options: [
+        "The WCAG supporting documents — the Understanding texts, the Techniques, and the ARIA Authoring Practices Guide",
+        "The auditor's preferred automated scanner, whose output is authoritative",
+        "The W3C Accessibility Maturity Model's procurement dimension",
+        "Annex B of EN 301 549, which lists required coding patterns for widgets"
+      ],
+      correct: 0,
+      explanation: "The BoK notes that WCAG's normative text defines the requirement without prescribing a particular coding solution, and that supporting documents — the Understanding texts, the Techniques, and the ARIA Authoring Practices Guidelines — can be consulted to determine whether an issue counts as a normative failure or should be considered 'not best practice.' A failure should be flagged only when the deficiency clearly maps to documented WCAG Failures or clearly fails the criterion.",
+      wrongExplanations: {
+        1: "Automated tool output is not authoritative — tools implement heuristics and miss context, especially for custom widgets. Borderline conformance calls require human judgment grounded in the normative text and its supporting documents.",
+        2: "The maturity model's procurement dimension assesses organizational purchasing processes. It says nothing about whether a specific widget fails a Success Criterion.",
+        3: "EN 301 549 Annex B maps requirements to user accessibility needs (useful for impact analysis); it does not prescribe coding patterns, and it isn't the reference for WCAG failure-vs-best-practice calls."
+      },
+      topicLinks: ['stakeholder-communication', 'failures-vs-best-practices', 'normative-vs-non-normative'],
+      difficulty: 'hard',
+      tags: ['wcag', 'understanding-docs', 'techniques', 'auditing']
     }
   ]
 };

--- a/src/hooks/useAnnounce.js
+++ b/src/hooks/useAnnounce.js
@@ -4,8 +4,8 @@ import { AnnounceContext } from '../components/common/LiveRegion';
 export function useAnnounce() {
   const announce = useContext(AnnounceContext);
   return useCallback(
-    (message) => {
-      if (announce) announce(message);
+    (message, priority) => {
+      if (announce) announce(message, priority);
     },
     [announce]
   );

--- a/src/hooks/usePracticeTest.js
+++ b/src/hooks/usePracticeTest.js
@@ -1,0 +1,392 @@
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+import { PRACTICE_CONFIG, MAX_HISTORY_PER_COURSE } from '../data/practiceConfig';
+import { drawPracticeTest, resolveEntries, gradeSession } from '../utils/practiceDraw';
+
+const INITIAL_SESSIONS = { version: 1, sessions: { cpacc: null, was: null } };
+const INITIAL_HISTORY = { version: 1, attempts: [] };
+const HEARTBEAT_MS = 15000;
+
+function sanitizeSessions(raw) {
+  if (!raw || raw.version !== 1 || typeof raw.sessions !== 'object' || raw.sessions === null) {
+    return INITIAL_SESSIONS;
+  }
+  return raw;
+}
+
+function sanitizeHistory(raw) {
+  if (!raw || raw.version !== 1 || !Array.isArray(raw.attempts)) {
+    return INITIAL_HISTORY;
+  }
+  return raw;
+}
+
+function isValidSession(s) {
+  return Boolean(
+    s &&
+    typeof s === 'object' &&
+    Array.isArray(s.entries) &&
+    s.entries.length > 0 &&
+    typeof s.timeLimitSec === 'number' &&
+    s.answers && typeof s.answers === 'object'
+  );
+}
+
+/** Elapsed seconds, computed from timestamps so interval throttling can't corrupt it. */
+function elapsedSecOf(session, nowMs) {
+  const base = session.elapsedBeforeSec || 0;
+  if (session.status === 'active' && session.lastResumedAt) {
+    return base + Math.max(0, (nowMs - session.lastResumedAt) / 1000);
+  }
+  return base;
+}
+
+/** Fold an 'active' session into a paused one, trusting time only up to the last heartbeat. */
+function foldToPaused(session, nowMs) {
+  const cutoff = Math.min(session.lastHeartbeatAt || nowMs, nowMs);
+  const elapsed = (session.elapsedBeforeSec || 0) +
+    (session.lastResumedAt ? Math.max(0, (cutoff - session.lastResumedAt) / 1000) : 0);
+  return { ...session, status: 'paused', elapsedBeforeSec: elapsed, lastResumedAt: null };
+}
+
+/**
+ * State for the full-length mock exam feature: one in-progress session per
+ * course (persisted so a test can be paused and resumed across reloads),
+ * a countdown timer derived from timestamps, and an attempt history.
+ *
+ * @param {object[]} allDomains - all domain objects (both courses)
+ * @param {object} domainsByCourse - { cpacc: [...], was: [...] }
+ * @param {string|null} activeCourseId - course of the session currently being
+ *   taken (from the route), or null outside the test view
+ * @param {function} [onComplete] - called with (courseId, score) when a test is submitted
+ */
+export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onComplete) {
+  const [rawSessions, setRawSessions] = useLocalStorage('pourcast-practice-session', INITIAL_SESSIONS);
+  const [rawHistory, setRawHistory] = useLocalStorage('pourcast-practice-history', INITIAL_HISTORY);
+  // Notices surfaced on PracticeHome (e.g. "time expired while you were away")
+  const [notices, setNotices] = useState([]);
+  // Render driver for the countdown display; time itself comes from timestamps
+  const [, setTick] = useState(0);
+
+  const sessionsData = sanitizeSessions(rawSessions);
+  const historyData = sanitizeHistory(rawHistory);
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  const updateSession = useCallback((courseId, updater) => {
+    setRawSessions((prev) => {
+      const data = sanitizeSessions(prev);
+      const session = data.sessions[courseId];
+      const next = updater(session);
+      if (next === session) return prev;
+      return { ...data, sessions: { ...data.sessions, [courseId]: next } };
+    });
+  }, [setRawSessions]);
+
+  /** Grade a session, record the attempt, clear the session. Returns attemptId or null. */
+  const finalizeAttempt = useCallback((session, { auto = false } = {}) => {
+    const { questions } = resolveEntries(session.entries, allDomains);
+    if (questions.length === 0) {
+      updateSession(session.courseId, () => null);
+      return null;
+    }
+    const result = gradeSession(session, questions);
+    const now = Date.now();
+    const attempt = {
+      id: `pt-${now}-${session.courseId}`,
+      courseId: session.courseId,
+      date: new Date().toISOString(),
+      score: result.score,
+      total: result.total,
+      percentage: result.percentage,
+      passed: result.passed,
+      perDomain: result.perDomain,
+      durationUsedSec: Math.round(Math.min(elapsedSecOf(session, now), session.timeLimitSec)),
+      completed: true,
+      autoSubmitted: auto,
+      detail: {
+        entries: session.entries,
+        answers: session.answers,
+        flagged: session.flagged || [],
+        eliminated: session.eliminated || {},
+      },
+    };
+    setRawHistory((prev) => {
+      const data = sanitizeHistory(prev);
+      // Keep full review detail only for the newest attempt per course
+      const olderStripped = data.attempts.map((a) =>
+        a.courseId === attempt.courseId && a.detail ? { ...a, detail: undefined } : a
+      );
+      const combined = [attempt, ...olderStripped];
+      const perCourseCount = {};
+      const capped = combined.filter((a) => {
+        perCourseCount[a.courseId] = (perCourseCount[a.courseId] || 0) + 1;
+        return perCourseCount[a.courseId] <= MAX_HISTORY_PER_COURSE;
+      });
+      return { version: 1, attempts: capped };
+    });
+    updateSession(session.courseId, () => null);
+    onCompleteRef.current?.(session.courseId, result.score);
+    return attempt.id;
+  }, [allDomains, setRawHistory, updateSession]);
+
+  // --- Crash/close recovery: an 'active' session at mount means the tab went
+  // away without pausing. Trust elapsed time only up to the last heartbeat,
+  // then pause — or auto-submit if the clock had already run out.
+  const recoveredRef = useRef(false);
+  useEffect(() => {
+    if (recoveredRef.current) return;
+    recoveredRef.current = true;
+    const now = Date.now();
+    for (const courseId of Object.keys(PRACTICE_CONFIG)) {
+      const session = sessionsData.sessions[courseId];
+      if (!session) continue;
+      if (!isValidSession(session)) {
+        updateSession(courseId, () => null);
+        setNotices((n) => [...n, { courseId, type: 'invalid' }]);
+        continue;
+      }
+      if (session.status === 'active') {
+        const paused = foldToPaused(session, now);
+        if (paused.elapsedBeforeSec >= session.timeLimitSec) {
+          const attemptId = finalizeAttempt(paused, { auto: true });
+          setNotices((n) => [...n, { courseId, type: 'expired', attemptId }]);
+        } else {
+          updateSession(courseId, () => paused);
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- Active session (the one the test view is showing) ---
+  const activeSession = activeCourseId ? sessionsData.sessions[activeCourseId] : null;
+  const activeValid = isValidSession(activeSession);
+  const activeEntries = activeValid ? activeSession.entries : null;
+
+  const resolved = useMemo(() => {
+    if (!activeEntries) return null;
+    return resolveEntries(activeEntries, allDomains);
+  }, [activeEntries, allDomains]);
+
+  // Session references question ids that no longer exist (app update) — the
+  // view should abandon it with an explanation rather than shrink the exam.
+  const invalidSession = Boolean(resolved && resolved.missingIds.length > 0);
+  const questions = resolved && !invalidSession ? resolved.questions : [];
+
+  const status = activeValid ? activeSession.status : null;
+  const remainingSec = activeValid
+    ? Math.max(0, Math.round(activeSession.timeLimitSec - elapsedSecOf(activeSession, Date.now())))
+    : null;
+
+  // Display tick — only re-renders; correctness lives in the timestamps
+  useEffect(() => {
+    if (status !== 'active') return undefined;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  // Heartbeat — bounds how much elapsed time a crash can claim
+  useEffect(() => {
+    if (status !== 'active' || !activeCourseId) return undefined;
+    const id = setInterval(() => {
+      updateSession(activeCourseId, (s) =>
+        s && s.status === 'active' ? { ...s, lastHeartbeatAt: Date.now() } : s
+      );
+    }, HEARTBEAT_MS);
+    return () => clearInterval(id);
+  }, [status, activeCourseId, updateSession]);
+
+  // Expiry while the view is open → auto-submit once
+  const [expiredAttempt, setExpiredAttempt] = useState(null);
+  const expiryFiredRef = useRef(false);
+  useEffect(() => {
+    if (status === 'active' && remainingSec <= 0 && !expiryFiredRef.current && activeSession) {
+      expiryFiredRef.current = true;
+      const attemptId = finalizeAttempt(activeSession, { auto: true });
+      setExpiredAttempt({ courseId: activeSession.courseId, attemptId });
+    }
+    if (status !== 'active') expiryFiredRef.current = false;
+  }, [status, remainingSec, activeSession, finalizeAttempt]);
+
+  // --- Actions ---
+
+  const startTest = useCallback((courseId) => {
+    const entries = drawPracticeTest(courseId, domainsByCourse);
+    if (!entries || entries.length === 0) return false;
+    const now = Date.now();
+    const session = {
+      id: `pt-${now}`,
+      courseId,
+      startedAt: new Date().toISOString(),
+      status: 'active',
+      timeLimitSec: PRACTICE_CONFIG[courseId].timeLimitSec,
+      elapsedBeforeSec: 0,
+      lastResumedAt: now,
+      lastHeartbeatAt: now,
+      entries,
+      currentIndex: 0,
+      answers: {},
+      flagged: [],
+      eliminated: {},
+    };
+    updateSession(courseId, () => session);
+    return true;
+  }, [domainsByCourse, updateSession]);
+
+  const resumeTest = useCallback((courseId) => {
+    const now = Date.now();
+    updateSession(courseId, (s) =>
+      s && s.status === 'paused'
+        ? { ...s, status: 'active', lastResumedAt: now, lastHeartbeatAt: now }
+        : s
+    );
+  }, [updateSession]);
+
+  const pauseTest = useCallback((courseId) => {
+    updateSession(courseId, (s) =>
+      s && s.status === 'active' ? foldToPaused(s, Date.now()) : s
+    );
+  }, [updateSession]);
+
+  const abandonTest = useCallback((courseId) => {
+    updateSession(courseId, () => null);
+  }, [updateSession]);
+
+  const selectAnswer = useCallback((qid, optionIndex) => {
+    if (!activeCourseId) return;
+    updateSession(activeCourseId, (s) => {
+      if (!s) return s;
+      const next = { ...s, answers: { ...s.answers, [qid]: optionIndex } };
+      // Picking an option un-eliminates it
+      const eliminatedForQ = s.eliminated?.[qid];
+      if (eliminatedForQ?.includes(optionIndex)) {
+        next.eliminated = {
+          ...s.eliminated,
+          [qid]: eliminatedForQ.filter((i) => i !== optionIndex),
+        };
+      }
+      return next;
+    });
+  }, [activeCourseId, updateSession]);
+
+  const toggleFlag = useCallback((qid) => {
+    if (!activeCourseId) return;
+    updateSession(activeCourseId, (s) => {
+      if (!s) return s;
+      const flagged = s.flagged || [];
+      return {
+        ...s,
+        flagged: flagged.includes(qid) ? flagged.filter((id) => id !== qid) : [...flagged, qid],
+      };
+    });
+  }, [activeCourseId, updateSession]);
+
+  const toggleEliminate = useCallback((qid, optionIndex) => {
+    if (!activeCourseId) return;
+    updateSession(activeCourseId, (s) => {
+      if (!s) return s;
+      const eliminatedForQ = s.eliminated?.[qid] || [];
+      const next = { ...s, eliminated: { ...s.eliminated } };
+      if (eliminatedForQ.includes(optionIndex)) {
+        next.eliminated[qid] = eliminatedForQ.filter((i) => i !== optionIndex);
+      } else {
+        next.eliminated[qid] = [...eliminatedForQ, optionIndex];
+        // Eliminating the selected option deselects it
+        if (s.answers?.[qid] === optionIndex) {
+          next.answers = { ...s.answers };
+          delete next.answers[qid];
+        }
+      }
+      return next;
+    });
+  }, [activeCourseId, updateSession]);
+
+  const goTo = useCallback((index) => {
+    if (!activeCourseId) return;
+    updateSession(activeCourseId, (s) => {
+      if (!s) return s;
+      const clamped = Math.max(0, Math.min(index, s.entries.length - 1));
+      return clamped === s.currentIndex ? s : { ...s, currentIndex: clamped };
+    });
+  }, [activeCourseId, updateSession]);
+
+  const submitTest = useCallback(() => {
+    if (!activeSession || !isValidSession(activeSession)) return null;
+    return finalizeAttempt(activeSession, { auto: false });
+  }, [activeSession, finalizeAttempt]);
+
+  const dismissNotice = useCallback((courseId, type) => {
+    setNotices((n) => n.filter((x) => !(x.courseId === courseId && x.type === type)));
+  }, []);
+
+  // --- History / summaries ---
+
+  const getAttempt = useCallback(
+    (attemptId) => historyData.attempts.find((a) => a.id === attemptId) || null,
+    [historyData.attempts]
+  );
+
+  const getSessionSummary = useCallback((courseId) => {
+    const s = sessionsData.sessions[courseId];
+    if (!isValidSession(s)) return null;
+    return {
+      courseId,
+      status: s.status,
+      startedAt: s.startedAt,
+      total: s.entries.length,
+      answeredCount: Object.keys(s.answers).length,
+      flaggedCount: (s.flagged || []).length,
+      remainingSec: Math.max(0, Math.round(s.timeLimitSec - elapsedSecOf(s, Date.now()))),
+    };
+  }, [sessionsData.sessions]);
+
+  const clearHistory = useCallback((courseId) => {
+    setRawHistory((prev) => {
+      const data = sanitizeHistory(prev);
+      return { version: 1, attempts: data.attempts.filter((a) => a.courseId !== courseId) };
+    });
+  }, [setRawHistory]);
+
+  // Derived state for the active session view
+  const currentIndex = activeValid ? activeSession.currentIndex : 0;
+  const answers = activeValid ? activeSession.answers : {};
+  const flaggedIds = activeValid ? activeSession.flagged || [] : [];
+  const eliminatedMap = activeValid ? activeSession.eliminated || {} : {};
+
+  return {
+    // active session state
+    session: activeValid ? activeSession : null,
+    invalidSession,
+    questions,
+    currentIndex,
+    currentQuestion: questions[currentIndex] || null,
+    answers,
+    flaggedIds,
+    eliminatedMap,
+    answeredCount: Object.keys(answers).length,
+    flaggedCount: flaggedIds.length,
+    status,
+    remainingSec,
+    expiredAttempt,
+    // actions
+    startTest,
+    resumeTest,
+    pauseTest,
+    abandonTest,
+    selectAnswer,
+    toggleFlag,
+    toggleEliminate,
+    goTo,
+    submitTest,
+    // home/history
+    notices,
+    dismissNotice,
+    history: historyData.attempts,
+    getAttempt,
+    getSessionSummary,
+    clearHistory,
+  };
+}

--- a/src/hooks/useQuiz.js
+++ b/src/hooks/useQuiz.js
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { shuffle } from '../utils/shuffle';
+import { applyOptionOrder, randomOptionOrder } from '../utils/applyOptionOrder';
 
 const QUESTIONS_PER_LESSON = 10;
 
@@ -8,29 +9,7 @@ const QUESTIONS_PER_LESSON = 10;
  * so the answer data stays consistent with the new option order.
  */
 function shuffleOptions(question) {
-  // Build an array of indices for all options and shuffle them
-  const indices = question.options.map((_, i) => i);
-  const shuffledIndices = shuffle(indices);
-
-  const newOptions = shuffledIndices.map((i) => question.options[i]);
-  const newCorrect = shuffledIndices.indexOf(question.correct);
-
-  // Remap wrongExplanations keys from old indices to new indices
-  let newWrongExplanations;
-  if (question.wrongExplanations) {
-    newWrongExplanations = {};
-    for (const [oldIdx, text] of Object.entries(question.wrongExplanations)) {
-      const newIdx = shuffledIndices.indexOf(Number(oldIdx));
-      newWrongExplanations[newIdx] = text;
-    }
-  }
-
-  return {
-    ...question,
-    options: newOptions,
-    correct: newCorrect,
-    wrongExplanations: newWrongExplanations || question.wrongExplanations,
-  };
+  return applyOptionOrder(question, randomOptionOrder(question));
 }
 
 export function useQuiz() {

--- a/src/index.css
+++ b/src/index.css
@@ -386,3 +386,28 @@ body {
 .hover-surface:focus-visible {
   background-color: var(--bg-surface-hover) !important;
 }
+
+/* ============================================================
+   Mock exam (practice test) styles
+   ============================================================ */
+
+/* Native <dialog> styling for ModalDialog */
+.practice-dialog {
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
+  border: 2px solid var(--border-strong);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  max-width: 36rem;
+  width: calc(100vw - 2rem);
+}
+
+.practice-dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+/* The answer radio is visually hidden, so draw its focus ring on the card */
+.practice-option:has(input:focus-visible) {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
+}

--- a/src/utils/applyOptionOrder.js
+++ b/src/utils/applyOptionOrder.js
@@ -1,0 +1,40 @@
+import { shuffle } from './shuffle';
+
+/**
+ * Reorder a question's options using an explicit permutation, remapping
+ * `correct` and `wrongExplanations` so the answer data stays consistent.
+ *
+ * @param {object} question - Question with options, correct, wrongExplanations
+ * @param {number[]} order - Permutation of original option indices, e.g. [2,0,3,1]
+ *   means the new first option is the original options[2].
+ * @returns {object} New question object with reordered options
+ */
+export function applyOptionOrder(question, order) {
+  const newOptions = order.map((i) => question.options[i]);
+  const newCorrect = order.indexOf(question.correct);
+
+  let newWrongExplanations;
+  if (question.wrongExplanations) {
+    newWrongExplanations = {};
+    for (const [oldIdx, text] of Object.entries(question.wrongExplanations)) {
+      const newIdx = order.indexOf(Number(oldIdx));
+      newWrongExplanations[newIdx] = text;
+    }
+  }
+
+  return {
+    ...question,
+    options: newOptions,
+    correct: newCorrect,
+    wrongExplanations: newWrongExplanations || question.wrongExplanations,
+  };
+}
+
+/**
+ * Generate a random option permutation for a question.
+ * @param {object} question
+ * @returns {number[]} Shuffled array of option indices
+ */
+export function randomOptionOrder(question) {
+  return shuffle(question.options.map((_, i) => i));
+}

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -1,0 +1,22 @@
+/** Format seconds as a clock string: 7140 → "1:59:00", 2832 → "47:12". */
+export function formatClock(totalSec) {
+  const sec = Math.max(0, Math.round(totalSec));
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  const mm = h > 0 ? String(m).padStart(2, '0') : String(m);
+  const ss = String(s).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/** Format seconds as spoken-friendly text: 5400 → "1 hour 30 minutes". */
+export function formatSpoken(totalSec) {
+  const sec = Math.max(0, Math.round(totalSec));
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const parts = [];
+  if (h > 0) parts.push(`${h} hour${h === 1 ? '' : 's'}`);
+  if (m > 0) parts.push(`${m} minute${m === 1 ? '' : 's'}`);
+  if (parts.length === 0) parts.push(`${sec % 60} seconds`);
+  return parts.join(' ');
+}

--- a/src/utils/practiceDraw.js
+++ b/src/utils/practiceDraw.js
@@ -1,0 +1,92 @@
+import { shuffle } from './shuffle';
+import { applyOptionOrder, randomOptionOrder } from './applyOptionOrder';
+import { PRACTICE_CONFIG } from '../data/practiceConfig';
+
+/**
+ * Draw a full mock exam for a course: a stratified random sample per domain
+ * (matching the real exam's 40/40/20 weighting), interleaved like the real
+ * exam. Each entry is fully serializable so a saved session restores the
+ * exact same test — same questions, same option order.
+ *
+ * @param {string} courseId - 'cpacc' | 'was'
+ * @param {object} domainsByCourse - { cpacc: [domain...], was: [domain...] }
+ * @returns {Array<{qid:number, domainId:string, optionOrder:number[]}>|null}
+ *   null if the course/config is unknown
+ */
+export function drawPracticeTest(courseId, domainsByCourse) {
+  const config = PRACTICE_CONFIG[courseId];
+  const domains = domainsByCourse[courseId];
+  if (!config || !domains) return null;
+
+  const entries = [];
+  for (const { domainId, count } of config.domains) {
+    const domain = domains.find((d) => d.id === domainId);
+    if (!domain) continue;
+    const picked = shuffle(domain.questions).slice(0, Math.min(count, domain.questions.length));
+    for (const q of picked) {
+      entries.push({ qid: q.id, domainId, optionOrder: randomOptionOrder(q) });
+    }
+  }
+  // Interleave domains the way the real exam does
+  return shuffle(entries);
+}
+
+/**
+ * Resolve serialized session entries back into full question objects with
+ * the stored option order applied.
+ *
+ * @param {Array} entries - [{qid, domainId, optionOrder}]
+ * @param {Array} allDomains - all domain objects (both courses)
+ * @returns {{questions: object[], missingIds: number[]}}
+ *   questions[i] corresponds to entries[i]; missing qids (e.g. removed in an
+ *   app update) are reported in missingIds and skipped in questions.
+ */
+export function resolveEntries(entries, allDomains) {
+  const byId = new Map();
+  for (const domain of allDomains) {
+    for (const q of domain.questions) byId.set(q.id, q);
+  }
+
+  const questions = [];
+  const missingIds = [];
+  for (const entry of entries) {
+    const q = byId.get(entry.qid);
+    if (!q) {
+      missingIds.push(entry.qid);
+      continue;
+    }
+    questions.push(applyOptionOrder(q, entry.optionOrder));
+  }
+  return { questions, missingIds };
+}
+
+/**
+ * Grade a finished session. Unanswered questions count as incorrect.
+ *
+ * @param {object} session - { courseId, entries, answers: {qid: selectedIdx} }
+ * @param {object[]} questions - resolved questions aligned with session.entries
+ * @returns {{score:number, total:number, percentage:number, passed:boolean,
+ *            perDomain: Object<string,{correct:number,total:number}>}}
+ */
+export function gradeSession(session, questions) {
+  const config = PRACTICE_CONFIG[session.courseId];
+  const byId = new Map(questions.map((q) => [q.id, q]));
+
+  let score = 0;
+  const perDomain = {};
+  for (const entry of session.entries) {
+    const q = byId.get(entry.qid);
+    if (!q) continue;
+    if (!perDomain[entry.domainId]) perDomain[entry.domainId] = { correct: 0, total: 0 };
+    perDomain[entry.domainId].total += 1;
+    if (session.answers?.[entry.qid] === q.correct) {
+      score += 1;
+      perDomain[entry.domainId].correct += 1;
+    }
+  }
+
+  const total = questions.length;
+  const percentage = total > 0 ? Math.round((score / total) * 100) : 0;
+  const passed = percentage >= (config?.passPercent ?? 100);
+  return { score, total, percentage, passed, perDomain };
+}

--- a/src/utils/practiceDraw.js
+++ b/src/utils/practiceDraw.js
@@ -38,8 +38,10 @@ export function drawPracticeTest(courseId, domainsByCourse) {
  * @param {Array} entries - [{qid, domainId, optionOrder}]
  * @param {Array} allDomains - all domain objects (both courses)
  * @returns {{questions: object[], missingIds: number[]}}
- *   questions[i] corresponds to entries[i]; missing qids (e.g. removed in an
- *   app update) are reported in missingIds and skipped in questions.
+ *   questions holds the resolved questions in entry order but EXCLUDES
+ *   missing qids (e.g. removed in an app update), so it is not positionally
+ *   aligned with entries when missingIds is non-empty. Missing qids are
+ *   reported in missingIds.
  */
 export function resolveEntries(entries, allDomains) {
   const byId = new Map();
@@ -61,10 +63,12 @@ export function resolveEntries(entries, allDomains) {
 }
 
 /**
- * Grade a finished session. Unanswered questions count as incorrect.
+ * Grade a finished session. Unanswered questions count as incorrect, and so
+ * do entries whose question no longer resolves (removed in an app update) —
+ * dropping them from the denominator would inflate the score.
  *
  * @param {object} session - { courseId, entries, answers: {qid: selectedIdx} }
- * @param {object[]} questions - resolved questions aligned with session.entries
+ * @param {object[]} questions - resolved questions from resolveEntries
  * @returns {{score:number, total:number, percentage:number, passed:boolean,
  *            perDomain: Object<string,{correct:number,total:number}>}}
  */
@@ -75,17 +79,16 @@ export function gradeSession(session, questions) {
   let score = 0;
   const perDomain = {};
   for (const entry of session.entries) {
-    const q = byId.get(entry.qid);
-    if (!q) continue;
     if (!perDomain[entry.domainId]) perDomain[entry.domainId] = { correct: 0, total: 0 };
     perDomain[entry.domainId].total += 1;
-    if (session.answers?.[entry.qid] === q.correct) {
+    const q = byId.get(entry.qid);
+    if (q && session.answers?.[entry.qid] === q.correct) {
       score += 1;
       perDomain[entry.domainId].correct += 1;
     }
   }
 
-  const total = questions.length;
+  const total = session.entries.length;
   const percentage = total > 0 ? Math.round((score / total) * 100) : 0;
   const passed = percentage >= (config?.passPercent ?? 100);
   return { score, total, percentage, passed, perDomain };

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,10 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: '/pourcast/',
+  server: {
+    watch: {
+      // Browser-automation artifacts; watching them causes an HMR feedback loop
+      ignored: ['**/.playwright-mcp/**'],
+    },
+  },
 })


### PR DESCRIPTION
- Introduced new topics for the WAS Body of Knowledge Domain Three, focusing on remediating accessibility issues, including procurement expert roles and stakeholder communication.
- Created a practice exam configuration for CPACC and WAS, detailing question counts, time limits, and passing percentages.
- Implemented a custom hook for managing practice test sessions, including session state, history tracking, and exam submission logic.
- Developed utility functions for applying option order to questions and formatting time for exam sessions.
- Added functionality to draw practice tests with stratified random sampling of questions based on domain weightings.