### PR TITLE
Add review status functionality to topics and implement reviewed topics hook

### DIFF
--- a/src/components/knowledge/KnowledgeHome.jsx
+++ b/src/components/knowledge/KnowledgeHome.jsx
@@ -1,7 +1,8 @@
 import { useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { Search, BookOpen, ChevronDown, ChevronRight } from 'lucide-react';
+import { Search, BookOpen, ChevronDown, ChevronRight, Check } from 'lucide-react';
 import { usePageFocus } from '../../hooks/usePageFocus';
+import { useReviewedTopics } from '../../hooks/useReviewedTopics';
 import { topics, getAllCategories, getTopicsByCategory } from '../../data/knowledgeBase/index';
 
 const FILTERS = [
@@ -10,18 +11,30 @@ const FILTERS = [
   { value: 'was', label: 'WAS' },
 ];
 
+const REVIEW_FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'unreviewed', label: 'Unreviewed' },
+  { value: 'reviewed', label: 'Reviewed' },
+];
+
 export default function KnowledgeHome() {
   const [search, setSearch] = useState('');
   const [testFilter, setTestFilter] = useState('all');
+  const [reviewFilter, setReviewFilter] = useState('all');
   const [expandedCategory, setExpandedCategory] = useState(null);
   const headingRef = useRef(null);
   const categories = getAllCategories();
+  const { isReviewed } = useReviewedTopics();
 
   usePageFocus(headingRef);
 
   function matchesFilter(topic) {
-    if (testFilter === 'all') return true;
-    return topic.applicableTo?.includes(testFilter);
+    const certOk = testFilter === 'all' || topic.applicableTo?.includes(testFilter);
+    const reviewed = isReviewed(topic.slug);
+    const reviewOk =
+      reviewFilter === 'all' ||
+      (reviewFilter === 'reviewed' ? reviewed : !reviewed);
+    return certOk && reviewOk;
   }
 
   const filteredTopics = search.trim()
@@ -53,9 +66,16 @@ export default function KnowledgeHome() {
         </p>
       </div>
 
+      <p
+        id="cert-filter-label"
+        className="text-base font-semibold mb-1"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        Certification
+      </p>
       <div
         role="group"
-        aria-label="Filter by certification"
+        aria-labelledby="cert-filter-label"
         className="flex rounded-xl p-1 mb-4 gap-1"
         style={{ backgroundColor: 'var(--bg-surface-hover)' }}
       >
@@ -69,6 +89,36 @@ export default function KnowledgeHome() {
               backgroundColor: testFilter === value ? 'var(--bg-surface)' : 'transparent',
               color: testFilter === value ? 'var(--text-accent)' : 'var(--text-secondary)',
               boxShadow: testFilter === value ? 'var(--shadow)' : 'none',
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <p
+        id="review-filter-label"
+        className="text-base font-semibold mb-1"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        Review status
+      </p>
+      <div
+        role="group"
+        aria-labelledby="review-filter-label"
+        className="flex rounded-xl p-1 mb-4 gap-1"
+        style={{ backgroundColor: 'var(--bg-surface-hover)' }}
+      >
+        {REVIEW_FILTERS.map(({ value, label }) => (
+          <button
+            key={value}
+            onClick={() => setReviewFilter(value)}
+            aria-pressed={reviewFilter === value}
+            className="flex-1 py-2 px-3 rounded-lg text-base font-semibold transition-colors text-center"
+            style={{
+              backgroundColor: reviewFilter === value ? 'var(--bg-surface)' : 'transparent',
+              color: reviewFilter === value ? 'var(--text-accent)' : 'var(--text-secondary)',
+              boxShadow: reviewFilter === value ? 'var(--shadow)' : 'none',
             }}
           >
             {label}
@@ -113,7 +163,7 @@ export default function KnowledgeHome() {
           ) : (
             <div className="space-y-2">
               {filteredTopics.map((topic) => (
-                <TopicRow key={topic.slug} topic={topic} />
+                <TopicRow key={topic.slug} topic={topic} reviewed={isReviewed(topic.slug)} />
               ))}
             </div>
           )}
@@ -159,7 +209,7 @@ export default function KnowledgeHome() {
                       }}
                     >
                       {catTopics.map((topic) => (
-                        <TopicRow key={topic.slug} topic={topic} />
+                        <TopicRow key={topic.slug} topic={topic} reviewed={isReviewed(topic.slug)} />
                       ))}
                     </div>
                   )}
@@ -173,7 +223,7 @@ export default function KnowledgeHome() {
   );
 }
 
-function TopicRow({ topic }) {
+function TopicRow({ topic, reviewed }) {
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -192,9 +242,19 @@ function TopicRow({ topic }) {
         <h3 className="font-medium text-base" style={{ color: hovered ? 'var(--text-accent)' : 'var(--text-primary)' }}>
           {topic.title}
         </h3>
-        {topic.applicableTo && (
-          <div className="flex gap-1 shrink-0">
-            {topic.applicableTo.map((tag) => (
+        <div className="flex items-center gap-1 shrink-0">
+          {reviewed && (
+            <span
+              className="inline-flex items-center gap-1"
+              style={{ color: 'var(--text-accent)' }}
+            >
+              <Check size={16} aria-hidden="true" />
+              <span className="sr-only">Reviewed</span>
+            </span>
+          )}
+          {topic.applicableTo && (
+            <div className="flex gap-1">
+              {topic.applicableTo.map((tag) => (
               <span
                 key={tag}
                 className="px-2 py-0.5 rounded-full text-base font-medium"
@@ -206,9 +266,10 @@ function TopicRow({ topic }) {
               >
                 {tag.toUpperCase()}
               </span>
-            ))}
-          </div>
-        )}
+              ))}
+            </div>
+          )}
+        </div>
       </div>
       <p className="text-base mt-0.5 line-clamp-1" style={{ color: 'var(--text-secondary)' }}>{topic.summary}</p>
     </Link>

--- a/src/components/knowledge/TopicPage.jsx
+++ b/src/components/knowledge/TopicPage.jsx
@@ -2,11 +2,13 @@ import { useRef, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, BookOpen, Lightbulb } from 'lucide-react';
 import { getTopicBySlug } from '../../data/knowledgeBase/index';
+import { useReviewedTopics } from '../../hooks/useReviewedTopics';
 
 export default function TopicPage() {
   const { slug } = useParams();
   const topic = getTopicBySlug(slug);
   const headingRef = useRef(null);
+  const { isReviewed, setReviewedStatus } = useReviewedTopics();
 
   useEffect(() => {
     headingRef.current?.focus();
@@ -118,6 +120,24 @@ export default function TopicPage() {
       )}
 
       <div className="mt-10 pt-6 border-t" style={{ borderColor: 'var(--border-default)' }}>
+        <label
+          htmlFor="mark-reviewed"
+          className="flex items-center gap-3 cursor-pointer text-base font-medium"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          <input
+            id="mark-reviewed"
+            type="checkbox"
+            checked={isReviewed(topic.slug)}
+            onChange={(e) => setReviewedStatus(topic.slug, e.target.checked)}
+            className="w-5 h-5 shrink-0"
+            style={{ accentColor: 'var(--text-accent)' }}
+          />
+          Mark this topic as reviewed
+        </label>
+      </div>
+
+      <div className="mt-6">
         <Link
           to="/learn"
           className="inline-flex items-center gap-2 font-medium no-underline"

--- a/src/hooks/useReviewedTopics.js
+++ b/src/hooks/useReviewedTopics.js
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+
+/**
+ * Tracks which knowledge base topics the user has marked as reviewed.
+ * Topics are identified globally by slug.
+ * Shape: { 'medical-model': true, 'wcag-principles': true }
+ */
+export function useReviewedTopics() {
+  const [reviewed, setReviewed] = useLocalStorage('pourcast-reviewed-topics', {});
+
+  const isReviewed = useCallback((slug) => reviewed[slug] === true, [reviewed]);
+
+  const setReviewedStatus = useCallback((slug, value) => {
+    setReviewed((prev) => {
+      if (value) return { ...prev, [slug]: true };
+      const { [slug]: _omit, ...rest } = prev;
+      return rest;
+    });
+  }, [setReviewed]);
+
+  return { reviewed, isReviewed, setReviewedStatus };
+}


### PR DESCRIPTION
This pull request adds a "reviewed" tracking feature to the knowledge base, allowing users to mark topics as reviewed and filter topics based on their review status. It introduces a new `useReviewedTopics` hook, updates the topic list and topic page UI to support marking and displaying reviewed topics, and adds a review status filter alongside the existing certification filter.

**Reviewed Topics Feature:**

* Added a new `useReviewedTopics` hook to manage and persist the reviewed status of knowledge base topics using local storage.
* Updated `KnowledgeHome.jsx` to:
  - Add a "Review status" filter (All, Unreviewed, Reviewed) for browsing topics. [[1]](diffhunk://#diff-8377b81d042845d1d80b7cba0ef59e0f5486330605bd19dd111a5c21a189ce4aR14-R37) [[2]](diffhunk://#diff-8377b81d042845d1d80b7cba0ef59e0f5486330605bd19dd111a5c21a189ce4aR99-R128)
  - Display a checkmark icon next to reviewed topics in the topic list.
  - Pass reviewed status to `TopicRow` for conditional rendering. [[1]](diffhunk://#diff-8377b81d042845d1d80b7cba0ef59e0f5486330605bd19dd111a5c21a189ce4aL116-R166) [[2]](diffhunk://#diff-8377b81d042845d1d80b7cba0ef59e0f5486330605bd19dd111a5c21a189ce4aL162-R212) [[3]](diffhunk://#diff-8377b81d042845d1d80b7cba0ef59e0f5486330605bd19dd111a5c21a189ce4aL176-R226)

**Topic Page Enhancements:**

* Updated `TopicPage.jsx` to allow users to mark a topic as reviewed via a checkbox, which updates the reviewed status using the new hook. [[1]](diffhunk://#diff-b85b144cf9bc9ec24207c442b972411115348d2f977b38e02b0d9ff07b4eb3fdR5-R11) [[2]](diffhunk://#diff-b85b144cf9bc9ec24207c442b972411115348d2f977b38e02b0d9ff07b4eb3fdR123-R140)

**Filtering Improvements:**

* Modified the topic filtering logic in `KnowledgeHome.jsx` to support combined filtering by certification and reviewed status.

These changes collectively improve user experience by enabling personalized progress tracking and more flexible browsing of knowledge base topics.