### PR TITLE
Add flaggedBank support to practice test and feedback components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -185,6 +185,7 @@ export default function App() {
                   allDomains={ALL_DOMAINS}
                   domainsByCourse={DOMAINS_BY_COURSE}
                   onPracticeComplete={recordPracticeCompletion}
+                  flaggedBank={flaggedBank}
                 />
               }
             />

--- a/src/components/practice/PracticeLayout.jsx
+++ b/src/components/practice/PracticeLayout.jsx
@@ -10,12 +10,12 @@ import PracticeResults from './PracticeResults';
  * session, timer, and history state are shared (and never duplicated against
  * the same localStorage keys).
  */
-export default function PracticeLayout({ allDomains, domainsByCourse, onPracticeComplete }) {
+export default function PracticeLayout({ allDomains, domainsByCourse, onPracticeComplete, flaggedBank }) {
   const match = useMatch('/practice/test/:courseId');
   const matchedCourse = match?.params?.courseId;
   const activeCourseId = matchedCourse && PRACTICE_CONFIG[matchedCourse] ? matchedCourse : null;
 
-  const practice = usePracticeTest(allDomains, domainsByCourse, activeCourseId, onPracticeComplete);
+  const practice = usePracticeTest(allDomains, domainsByCourse, activeCourseId, onPracticeComplete, flaggedBank);
 
   return (
     <Routes>

--- a/src/components/quiz/FeedbackPanel.jsx
+++ b/src/components/quiz/FeedbackPanel.jsx
@@ -3,7 +3,7 @@ import { CheckCircle, XCircle, ChevronDown, ChevronUp, Flag } from 'lucide-react
 import { getEncouragement } from '../../utils/encouragement';
 import TopicLinks from './TopicLinks';
 
-export default function FeedbackPanel({ question, feedback, onNext, isFlagged, onToggleFlag }) {
+export default function FeedbackPanel({ question, feedback, onNext, isFlagged, flagNote, onToggleFlag, onSaveNote }) {
   const [showExplanation, setShowExplanation] = useState(false);
   const [showNoteInput, setShowNoteInput] = useState(false);
   const [noteText, setNoteText] = useState('');
@@ -91,12 +91,11 @@ export default function FeedbackPanel({ question, feedback, onNext, isFlagged, o
 
       {onToggleFlag && (
         <div className="mt-4">
-          {!isFlagged && !showNoteInput && (
+          {!isFlagged ? (
+            // One click flags the question immediately — no second confirmation
+            // step, so a flag can never be silently lost by navigating away.
             <button
-              onClick={() => {
-                setShowNoteInput(true);
-                setTimeout(() => noteInputRef.current?.focus(), 0);
-              }}
+              onClick={() => onToggleFlag(null)}
               aria-pressed={false}
               className="flex items-center gap-2 py-2 px-3 rounded-lg text-base font-medium transition-colors border-2 bg-transparent cursor-pointer"
               style={{
@@ -107,86 +106,111 @@ export default function FeedbackPanel({ question, feedback, onNext, isFlagged, o
               <Flag size={16} aria-hidden="true" />
               Flag this question
             </button>
-          )}
-
-          {!isFlagged && showNoteInput && (
+          ) : (
             <div className="flex flex-col gap-2">
-              <label
-                htmlFor="flag-note"
-                className="text-base font-medium"
-                style={{ color: 'var(--info-text)' }}
-              >
-                Why are you flagging this? (optional)
-              </label>
-              <input
-                ref={noteInputRef}
-                id="flag-note"
-                type="text"
-                maxLength={100}
-                value={noteText}
-                onChange={(e) => setNoteText(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    onToggleFlag(noteText.trim() || null);
-                    setShowNoteInput(false);
-                    setNoteText('');
-                  }
-                }}
-                placeholder="e.g., Seems like WAS material"
-                className="py-2 px-3 rounded-lg text-base border-2"
-                style={{
-                  borderColor: 'var(--info-border)',
-                  backgroundColor: 'var(--bg-surface)',
-                  color: 'var(--text-primary)',
-                }}
-              />
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <button
                   onClick={() => {
-                    onToggleFlag(noteText.trim() || null);
+                    onToggleFlag();
                     setShowNoteInput(false);
                     setNoteText('');
                   }}
-                  className="flex items-center gap-2 py-2 px-3 rounded-lg text-base font-medium transition-colors border-0 cursor-pointer"
+                  aria-pressed={true}
+                  className="flex items-center gap-2 py-2 px-3 rounded-lg text-base font-medium transition-colors border-2 cursor-pointer"
                   style={{
-                    backgroundColor: 'var(--info-border)',
-                    color: '#fff',
+                    borderColor: 'var(--info-border)',
+                    backgroundColor: 'var(--info-bg)',
+                    color: 'var(--info-text)',
                   }}
                 >
-                  <Flag size={16} aria-hidden="true" />
-                  Flag
+                  <Flag size={16} aria-hidden="true" fill="currentColor" />
+                  Flagged
                 </button>
-                <button
-                  onClick={() => {
-                    setShowNoteInput(false);
-                    setNoteText('');
-                  }}
-                  className="py-2 px-3 rounded-lg text-base font-medium transition-colors border-2 bg-transparent cursor-pointer"
-                  style={{
-                    borderColor: 'var(--border-default)',
-                    color: 'var(--text-muted)',
-                  }}
-                >
-                  Cancel
-                </button>
+                {!showNoteInput && (
+                  <button
+                    onClick={() => {
+                      setNoteText(flagNote || '');
+                      setShowNoteInput(true);
+                      setTimeout(() => noteInputRef.current?.focus(), 0);
+                    }}
+                    className="py-2 px-3 rounded-lg text-base font-medium transition-colors border-2 bg-transparent cursor-pointer"
+                    style={{
+                      borderColor: 'var(--info-border)',
+                      color: 'var(--info-text)',
+                    }}
+                  >
+                    {flagNote ? 'Edit note' : 'Add note'}
+                  </button>
+                )}
               </div>
-            </div>
-          )}
 
-          {isFlagged && (
-            <button
-              onClick={() => onToggleFlag()}
-              aria-pressed={true}
-              className="flex items-center gap-2 py-2 px-3 rounded-lg text-base font-medium transition-colors border-2 cursor-pointer"
-              style={{
-                borderColor: 'var(--info-border)',
-                backgroundColor: 'var(--info-bg)',
-                color: 'var(--info-text)',
-              }}
-            >
-              <Flag size={16} aria-hidden="true" fill="currentColor" />
-              Flagged
-            </button>
+              {flagNote && !showNoteInput && (
+                <p
+                  className="text-base italic px-3 py-2 rounded-lg"
+                  style={{ color: 'var(--info-text)', backgroundColor: 'var(--info-bg)' }}
+                >
+                  {flagNote}
+                </p>
+              )}
+
+              {showNoteInput && (
+                <div className="flex flex-col gap-2">
+                  <label
+                    htmlFor="flag-note"
+                    className="text-base font-medium"
+                    style={{ color: 'var(--info-text)' }}
+                  >
+                    Why are you flagging this? (optional)
+                  </label>
+                  <input
+                    ref={noteInputRef}
+                    id="flag-note"
+                    type="text"
+                    maxLength={100}
+                    value={noteText}
+                    onChange={(e) => setNoteText(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        onSaveNote(noteText.trim() || null);
+                        setShowNoteInput(false);
+                      }
+                    }}
+                    placeholder="e.g., Seems like WAS material"
+                    className="py-2 px-3 rounded-lg text-base border-2"
+                    style={{
+                      borderColor: 'var(--info-border)',
+                      backgroundColor: 'var(--bg-surface)',
+                      color: 'var(--text-primary)',
+                    }}
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => {
+                        onSaveNote(noteText.trim() || null);
+                        setShowNoteInput(false);
+                      }}
+                      className="py-2 px-3 rounded-lg text-base font-medium transition-colors border-0 cursor-pointer"
+                      style={{
+                        backgroundColor: 'var(--info-border)',
+                        color: '#fff',
+                      }}
+                    >
+                      Save note
+                    </button>
+                    <button
+                      onClick={() => setShowNoteInput(false)}
+                      className="py-2 px-3 rounded-lg text-base font-medium transition-colors border-2 bg-transparent cursor-pointer"
+                      style={{
+                        borderColor: 'var(--border-default)',
+                        color: 'var(--text-muted)',
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/components/quiz/QuizView.jsx
+++ b/src/components/quiz/QuizView.jsx
@@ -110,25 +110,34 @@ export default function QuizView({ quiz, domains, onUpdateStats, missedBank, fla
         onAnswer={quiz.submitAnswer}
       />
 
-      {quiz.feedback && (
-        <FeedbackPanel
-          question={quiz.currentQuestion}
-          feedback={quiz.feedback}
-          onNext={quiz.nextQuestion}
-          isFlagged={flaggedBank?.isFlagged(quiz.domain?.courseId || 'cpacc', quiz.currentQuestion?.id)}
-          onToggleFlag={(note) => {
-            const courseId = quiz.domain?.courseId || 'cpacc';
-            const qId = quiz.currentQuestion?.id;
-            if (flaggedBank?.isFlagged(courseId, qId)) {
-              flaggedBank.unflagQuestion(courseId, qId);
-              announce('Question unflagged');
-            } else {
-              flaggedBank.flagQuestion(courseId, qId, note);
-              announce('Question flagged');
-            }
-          }}
-        />
-      )}
+      {quiz.feedback && (() => {
+        const courseId = quiz.domain?.courseId || 'cpacc';
+        const qId = quiz.currentQuestion?.id;
+        const isFlagged = flaggedBank?.isFlagged(courseId, qId);
+        const flagNote = isFlagged ? flaggedBank.getFlaggedEntries(courseId)[qId] ?? null : null;
+        return (
+          <FeedbackPanel
+            question={quiz.currentQuestion}
+            feedback={quiz.feedback}
+            onNext={quiz.nextQuestion}
+            isFlagged={isFlagged}
+            flagNote={flagNote}
+            onToggleFlag={(note) => {
+              if (flaggedBank?.isFlagged(courseId, qId)) {
+                flaggedBank.unflagQuestion(courseId, qId);
+                announce('Question unflagged');
+              } else {
+                flaggedBank.flagQuestion(courseId, qId, note);
+                announce('Question flagged');
+              }
+            }}
+            onSaveNote={(note) => {
+              flaggedBank?.flagQuestion(courseId, qId, note);
+              announce(note ? 'Note saved' : 'Note removed');
+            }}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/src/hooks/usePracticeTest.js
+++ b/src/hooks/usePracticeTest.js
@@ -73,6 +73,9 @@ export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onC
   const sessionsData = sanitizeSessions(rawSessions);
   const historyData = sanitizeHistory(rawHistory);
   const onCompleteRef = useRef(onComplete);
+  // Queue of flag-mirror ops to apply to the persistent bank, decided inside the
+  // session's functional updater and flushed after commit (see toggleFlag).
+  const pendingFlagMirror = useRef([]);
   useEffect(() => {
     onCompleteRef.current = onComplete;
   }, [onComplete]);
@@ -276,21 +279,34 @@ export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onC
 
   const toggleFlag = useCallback((qid) => {
     if (!activeCourseId) return;
-    const session = sessionsData.sessions[activeCourseId];
-    const currentlyFlagged = (session?.flagged || []).includes(qid);
-    updateSession(activeCourseId, (s) => {
+    const course = activeCourseId;
+    updateSession(course, (s) => {
       if (!s) return s;
       const flagged = s.flagged || [];
+      const has = flagged.includes(qid);
+      // Decide the bank mirror from the real previous state, in order, so rapid
+      // toggles batched before a re-render stay consistent with the session.
+      pendingFlagMirror.current.push({ course, qid, flagged: !has });
       return {
         ...s,
-        flagged: flagged.includes(qid) ? flagged.filter((id) => id !== qid) : [...flagged, qid],
+        flagged: has ? flagged.filter((id) => id !== qid) : [...flagged, qid],
       };
     });
-    // Mirror into the persistent flagged bank so exam flags are unified with
-    // lesson flags on the dashboard card and /flagged page.
-    if (currentlyFlagged) flaggedBank?.unflagQuestion(activeCourseId, qid);
-    else flaggedBank?.flagQuestion(activeCourseId, qid);
-  }, [activeCourseId, sessionsData, updateSession, flaggedBank]);
+  }, [activeCourseId, updateSession]);
+
+  // Flush queued flag mirrors into the persistent bank after the session commits,
+  // applying them in dispatch order so the bank reflects the session's final state.
+  // flag/unflag are idempotent, so a duplicated op (e.g. StrictMode) is harmless.
+  useEffect(() => {
+    if (pendingFlagMirror.current.length === 0) return;
+    const ops = pendingFlagMirror.current;
+    pendingFlagMirror.current = [];
+    if (!flaggedBank) return;
+    for (const { course, qid, flagged } of ops) {
+      if (flagged) flaggedBank.flagQuestion(course, qid);
+      else flaggedBank.unflagQuestion(course, qid);
+    }
+  });
 
   const toggleEliminate = useCallback((qid, optionIndex) => {
     if (!activeCourseId) return;

--- a/src/hooks/usePracticeTest.js
+++ b/src/hooks/usePracticeTest.js
@@ -59,8 +59,10 @@ function foldToPaused(session, nowMs) {
  * @param {string|null} activeCourseId - course of the session currently being
  *   taken (from the route), or null outside the test view
  * @param {function} [onComplete] - called with (courseId, score) when a test is submitted
+ * @param {object} [flaggedBank] - useFlaggedBank instance; exam flags are mirrored
+ *   into it so they appear on the dashboard / flagged page alongside lesson flags
  */
-export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onComplete) {
+export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onComplete, flaggedBank) {
   const [rawSessions, setRawSessions] = useLocalStorage('pourcast-practice-session', INITIAL_SESSIONS);
   const [rawHistory, setRawHistory] = useLocalStorage('pourcast-practice-history', INITIAL_HISTORY);
   // Notices surfaced on PracticeHome (e.g. "time expired while you were away")
@@ -274,6 +276,8 @@ export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onC
 
   const toggleFlag = useCallback((qid) => {
     if (!activeCourseId) return;
+    const session = sessionsData.sessions[activeCourseId];
+    const currentlyFlagged = (session?.flagged || []).includes(qid);
     updateSession(activeCourseId, (s) => {
       if (!s) return s;
       const flagged = s.flagged || [];
@@ -282,7 +286,11 @@ export function usePracticeTest(allDomains, domainsByCourse, activeCourseId, onC
         flagged: flagged.includes(qid) ? flagged.filter((id) => id !== qid) : [...flagged, qid],
       };
     });
-  }, [activeCourseId, updateSession]);
+    // Mirror into the persistent flagged bank so exam flags are unified with
+    // lesson flags on the dashboard card and /flagged page.
+    if (currentlyFlagged) flaggedBank?.unflagQuestion(activeCourseId, qid);
+    else flaggedBank?.flagQuestion(activeCourseId, qid);
+  }, [activeCourseId, sessionsData, updateSession, flaggedBank]);
 
   const toggleEliminate = useCallback((qid, optionIndex) => {
     if (!activeCourseId) return;


### PR DESCRIPTION
This pull request introduces enhanced support for flagging questions with optional notes and ensures that flagged questions in practice tests are synchronized with the persistent flagged bank. The changes improve the user experience around flagging, allow users to add or edit notes to flagged questions, and unify the flagging system across lessons and exams.

**Flagging and Note Functionality Enhancements:**

* Updated the `FeedbackPanel` component to allow users to add, edit, and display notes when flagging questions, including a clearer UI for managing flagged status and notes. The flagging process now immediately flags a question on click, and users can add or edit notes to the flag, which are displayed alongside the flagged status. [[1]](diffhunk://#diff-baaba78bcc379aac41307e5a761f81f3d1a41a4b72dfe77b66d58c6a62eea53bL6-R6) [[2]](diffhunk://#diff-baaba78bcc379aac41307e5a761f81f3d1a41a4b72dfe77b66d58c6a62eea53bL94-R98) [[3]](diffhunk://#diff-baaba78bcc379aac41307e5a761f81f3d1a41a4b72dfe77b66d58c6a62eea53bR109-R156) [[4]](diffhunk://#diff-baaba78bcc379aac41307e5a761f81f3d1a41a4b72dfe77b66d58c6a62eea53bL130-L132) [[5]](diffhunk://#diff-baaba78bcc379aac41307e5a761f81f3d1a41a4b72dfe77b66d58c6a62eea53bL146-R201) [[6]](diffhunk://#diff-baaba78bcc379aac41307e5a761f81f3d1a41a4b72dfe77b66d58c6a62eea53bL175-R213)
* Modified the `QuizView` component to pass the appropriate flag status and note to the `FeedbackPanel`, and added handlers to save notes and synchronize flagging actions with the flagged bank. [[1]](diffhunk://#diff-d0a401ff97056b18b3c713616fe3643ab88aeb373a2ebe031597d9acd745a975L113-L121) [[2]](diffhunk://#diff-d0a401ff97056b18b3c713616fe3643ab88aeb373a2ebe031597d9acd745a975R134-R140)

**Practice Test and Flag Synchronization:**

* Updated the `PracticeLayout` and `App` components to pass the `flaggedBank` instance down to practice-related components, enabling synchronization of exam flags with the persistent flagged bank. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R188) [[2]](diffhunk://#diff-fa17959c6a718b3613c427e1e1cbc1d1bc7d4acdd5fc742360804eef7c7cd574L13-R18)
* Enhanced the `usePracticeTest` hook to accept a `flaggedBank` parameter and mirror flagging actions (flag/unflag) from practice sessions into the persistent flagged bank, ensuring a unified view of flagged questions across the app. [[1]](diffhunk://#diff-1dbc7627675c1c6f47b116b8f7f6be24d73935a2a8a980a17746770c0e572106R62-R65) [[2]](diffhunk://#diff-1dbc7627675c1c6f47b116b8f7f6be24d73935a2a8a980a17746770c0e572106R279-R280) [[3]](diffhunk://#diff-1dbc7627675c1c6f47b116b8f7f6be24d73935a2a8a980a17746770c0e572106L285-R293)